### PR TITLE
Fix link for markdown files

### DIFF
--- a/Sources/swift-doc/Supporting Types/Components/ConformingTypes.swift
+++ b/Sources/swift-doc/Supporting Types/Components/ConformingTypes.swift
@@ -28,7 +28,7 @@ struct ConformingTypes: Component {
                     #"""
                     \#(names.map { name in
                         if module.hasDeclaration(named: name) {
-                            return "[`\(name)`](\(path(for: name)))"
+                            return "[`\(name)`](\(path(for: name)).md)"
                         } else {
                             return "`\(name)`"
                         }

--- a/Sources/swift-doc/Supporting Types/Components/Inheritance.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Inheritance.swift
@@ -53,7 +53,7 @@ struct Inheritance: Component {
                         #"""
                         \#(inheritance.map {
                             if module.hasDeclaration(named: $0) {
-                                return "[`\($0)`](\(path(for: $0)))"
+                                return "[`\($0)`](\(path(for: $0)).md)"
                             } else {
                                 return "`\($0)`"
                             }

--- a/Sources/swift-doc/Supporting Types/Components/NestedTypes.swift
+++ b/Sources/swift-doc/Supporting Types/Components/NestedTypes.swift
@@ -25,7 +25,7 @@ struct NestedTypes: Component {
 
                 List(of: types.map { $0.declaration.qualifiedName }) { (name) -> ListItemConvertible in
                     if module.hasDeclaration(named: name) {
-                        return Link(urlString: path(for: name), text: name)
+                        return Link(urlString: "\(path(for: name)).md", text: name)
                     } else {
                         return Text(literal: name)
                     }

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -53,7 +53,7 @@ struct HomePage: Page {
                 if (!names.isEmpty) {
                     Heading { heading }
                     List(of: names.sorted()) { name in
-                        Link(urlString: path(for: name), text: name)
+                        Link(urlString: "\(path(for: name)).md", text: name)
                     }
                 }
             }
@@ -74,7 +74,7 @@ struct HomePage: Page {
                           Heading { heading }
                             
                           List(of: names.sorted()) { name in
-                              Link(urlString: path(for: name), text: name)
+                              Link(urlString: "\(path(for: name)).md", text: name)
                           }
                         }
                     }

--- a/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
@@ -64,7 +64,7 @@ struct SidebarPage: Page {
                 }
 
                 List(of: section.names.sorted()) { name in
-                    Link(urlString: path(for: name), text: name)
+                    Link(urlString: "\(path(for: name)).md", text: name)
                 }
 
                 Fragment { "</details>" }


### PR DESCRIPTION
# Description
As I user, I want to have the correct filename in the link for another file.

# Problem
The files generated had a correct name but in the generated content in the body of the markdown, the link missed ".md".

Here a little example:

```diff
// from
-[File](File)
// to
+[File](File.md)
```

Based on the changes I made, I would like to know if it make sense for you @mattt. 