### PR TITLE
swift-api-declarations: Add declarations in public protocols as public declarations

### DIFF
--- a/Sources/swift-api-inventory/Inventory.swift
+++ b/Sources/swift-api-inventory/Inventory.swift
@@ -2,9 +2,24 @@ import SwiftSemantics
 import SwiftDoc
 
 func inventory(of module: Module) -> [String] {
-    return module.symbols
+    let publicSymbols = module.symbols
         .filter { $0.isPublic }
-        .sorted()
+        
+    let publicProtocolNames = Set(publicSymbols
+        .filter { $0.declaration is Protocol }
+        .map { $0.declaration.qualifiedName })
+    
+        
+    let symbolsForPublicProtocols = module.symbols
+        .filter { symbol -> Bool in
+            guard let context = symbol.declaration.context else { return false }
+            return publicProtocolNames.contains(context)
+    }
+    
+    let inventory = publicSymbols + symbolsForPublicProtocols
+    
+    return inventory
+        .sorted
         .compactMap { representation(of: $0, in: module) }
 }
 


### PR DESCRIPTION
Hi Mattt,

This PR add support for correctly printing methods or properties defined in public protocols.
A protocol could be defined such as:
```swift
public Protocol {
  func publicMethod()
  var publicProperty()
}
```
Currently the implementation was skipping the method and the property as they are not marked with accessibility modifiers, in this case those are implicitly public.

While doing the PR I notice two things:
* We do not currently have any tests. Do we want experimental commands to be covered with tests?
* `Symbol` are currently defined with an `Array`. Did we considered using `Set` instead? I was just wondering if the choice of having `Array` instead of `Set` was because we care about the initial "order" or not. My assumption is that, if the order is not important, we may benefits from hashing in different contexts.

Thanks!

Edit:
Actually three things:
```swift
func representation(of symbol: Symbol, in module: Module) -> String?
```
Do we want to refactor this method to somehow unify the representationDescription of a symbol? Maybe under SwiftSemantics?