### PR TITLE
Update coverage command description

### DIFF
--- a/Sources/swift-doc/Subcommands/Coverage.swift
+++ b/Sources/swift-doc/Subcommands/Coverage.swift
@@ -14,7 +14,7 @@ extension SwiftDoc {
             var output: String?
         }
 
-        static var configuration = CommandConfiguration(abstract: "Generates Swift documentation")
+        static var configuration = CommandConfiguration(abstract: "Generates documentation coverage statistics for Swift files")
 
         @OptionGroup()
         var options: Options


### PR DESCRIPTION
When running `swift doc --help` both the `generate` and `coverage` subcommands have the same description.

```shell
OVERVIEW: A utility for generating documentation for Swift code.

USAGE: swift-doc <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  generate                Generates Swift documentation
  coverage                Generates Swift documentation
  diagram                 Generates diagram of Swift symbol relationships
```

This PR changes the `coverage` description to **“Generates documentation coverage statistics for Swift files”**. I took that string from the project’s readme section on the `coverage` command 😸 