### PR TITLE
Fix SourceFile Visitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Build and Test
-        run: swift test
+        run: swift test -c release
         env:
           DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
 
@@ -28,4 +28,4 @@ jobs:
           apt-get update
           apt-get install -y libxml2-dev
       - name: Build and Test
-        run: swift test --enable-test-discovery
+        run: swift test -c release --enable-test-discovery

--- a/Sources/SwiftDoc/SourceFile.swift
+++ b/Sources/SwiftDoc/SourceFile.swift
@@ -89,6 +89,7 @@ public struct SourceFile: Hashable, Codable {
             visitedImports.append(`import`)
         }
 
+        @discardableResult
         func pop() -> Contextual? {
             return context.popLast()
         }
@@ -187,27 +188,33 @@ public struct SourceFile: Hashable, Codable {
         // MARK: -
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            assert((pop() as? Symbol)?.api is Class)
+            let context = pop()
+            assert((context as? Symbol)?.api is Class)
         }
 
         override func visitPost(_ node: EnumDeclSyntax) {
-            assert((pop() as? Symbol)?.api is Enumeration)
+            let context = pop()
+            assert((context as? Symbol)?.api is Enumeration)
         }
 
         override func visitPost(_ node: ExtensionDeclSyntax) {
-            assert(pop() is Extension)
+            let context = pop()
+            assert(context is Extension)
         }
 
         override func visitPost(_ node: IfConfigClauseSyntax) {
-            assert(pop() is CompilationCondition)
+            let context = pop()
+            assert(context is CompilationCondition)
         }
 
         override func visitPost(_ node: ProtocolDeclSyntax) {
-            assert((pop() as? Symbol)?.api is Protocol)
+            let context = pop()
+            assert((context as? Symbol)?.api is Protocol)
         }
 
         override func visitPost(_ node: StructDeclSyntax) {
-            assert((pop() as? Symbol)?.api is Structure)
+            let context = pop()
+            assert((context as? Symbol)?.api is Structure)
         }
     }
 }

--- a/Tests/SwiftDocTests/SourceFileTests.swift
+++ b/Tests/SwiftDocTests/SourceFileTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import SwiftDoc
+import SwiftDoc
 import SwiftSemantics
 import struct SwiftSemantics.Protocol
 import SwiftSyntax


### PR DESCRIPTION
As described in #16, #25, and #35, running swift-doc in a GitHub Action produces strange results, with overly-long API symbol names. While I'd originally attributed my inability to reproduce these results to a macOS v. Linux difference, it turns out to have been a matter of debug v. release.

I verified this locally by running tests in release mode (with the small change of making the import of `SwiftDoc` non-`@testable`):

```terminal
$ swift test -c release
Test Suite 'All tests' failed at 2020-04-05 06:13:26.899.
	 Executed 1 test, with 12 failures (0 unexpected) in 0.072 (0.073) seconds
```

When building with a release configuration, the Swift compiler removes assertions. The problem with the current implementation is that we're doing something important in the assertion:

https://github.com/SwiftDocOrg/swift-doc/blob/85b5872e3cdb58be273d3dd2315fa101acbfbe3c/Sources/SwiftDoc/SourceFile.swift#L190
Separating out the work from the test in 7f9680e3131c961c16299a65b98b78c236ee0793 fixed the underlying issue.

To prevent such behavioral differences from creeping up again in the future, I updated the CI action to test in release mode going forward with 78967878a53a824becc592614b82c0a654cd99f9. Tests will run slower than before, but this will give us greater confidence in the results of the tests, since it matches the configuration of how `swift-doc` is built when running `make install`.