### PR TITLE
Fix nested type handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--base-url` option.
   #65 by @kean.
 
+### Fixed
+
+- Fixed relationship handling for members of nested types.
+  #62 by @victor-pavlychko.
+- Fixed rendering of type relationships section when no graph data is available.
+  #62 by @victor-pavlychko.
+  
+
 ## [1.0.0-beta.2] - 2020-04-08
 
 ### Changed

--- a/Sources/SwiftDoc/Interface.swift
+++ b/Sources/SwiftDoc/Interface.swift
@@ -55,9 +55,9 @@ public final class Interface: Codable {
     public private(set) lazy var relationships: [Relationship] = {
         var relationships: Set<Relationship> = []
         for symbol in symbols {
-            let owner = symbol.context.last(where: { $0 is Extension || $0 is Symbol })
+            let lastDeclarationScope = symbol.context.last(where: { $0 is Extension || $0 is Symbol })
 
-            if let container = owner as? Symbol {
+            if let container = lastDeclarationScope as? Symbol {
                 let predicate: Relationship.Predicate
 
                 switch container.api {
@@ -74,7 +74,7 @@ public final class Interface: Codable {
                 relationships.insert(Relationship(subject: symbol, predicate: predicate, object: container))
             }
 
-            if let `extension` = owner as? Extension {
+            if let `extension` = lastDeclarationScope as? Extension {
                 if let extended = symbols.first(where: { $0.api is Type &&  $0.id.matches(`extension`.extendedType) }) {
 
                     let predicate: Relationship.Predicate

--- a/Sources/SwiftDoc/Interface.swift
+++ b/Sources/SwiftDoc/Interface.swift
@@ -55,9 +55,9 @@ public final class Interface: Codable {
     public private(set) lazy var relationships: [Relationship] = {
         var relationships: Set<Relationship> = []
         for symbol in symbols {
-            let `extension` = symbol.context.compactMap({ $0 as? Extension }).first
+            let owner = symbol.context.last(where: { $0 is Extension || $0 is Symbol })
 
-            if let container = symbol.context.compactMap({ $0 as? Symbol }).last {
+            if let container = owner as? Symbol {
                 let predicate: Relationship.Predicate
 
                 switch container.api {
@@ -74,7 +74,7 @@ public final class Interface: Codable {
                 relationships.insert(Relationship(subject: symbol, predicate: predicate, object: container))
             }
 
-            if let `extension` = `extension` {
+            if let `extension` = owner as? Extension {
                 if let extended = symbols.first(where: { $0.api is Type &&  $0.id.matches(`extension`.extendedType) }) {
 
                     let predicate: Relationship.Predicate

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -90,7 +90,7 @@ struct Relationships: Component {
     }
 
     var html: HypertextLiteral.HTML {
-        guard sections.map({ $0.symbols.count }).reduce(0, +) != 0 else { return "" }
+        guard !sections.isEmpty else { return "" }
 
         return #"""
         <section id="relationships">
@@ -105,8 +105,6 @@ struct Relationships: Component {
                     """#
                 } ?? "")
                 \#(sections.compactMap { (heading, symbols) -> HypertextLiteral.HTML? in
-                    guard !symbols.isEmpty else { return nil }
-
                     let partitioned = symbols.filter { !($0.api is Unknown) } + symbols.filter { ($0.api is Unknown) }
 
                     return #"""

--- a/Tests/SwiftDocTests/NestedTypesTests.swift
+++ b/Tests/SwiftDocTests/NestedTypesTests.swift
@@ -65,4 +65,63 @@ final class NestedTypesTests: XCTestCase {
             [classRelationships, enumRelationships].joined().count
         )
     }
+
+    #if false // Disabling tests for `swift-doc` code, executable targers are not testable.
+
+    func testRelationshipsSectionWithNestedTypes() throws {
+        let source = #"""
+        public class C {
+            public enum E {
+            }
+        }
+        """#
+
+        let url = try temporaryFile(contents: source)
+        let sourceFile = try SourceFile(file: url, relativeTo: url.deletingLastPathComponent())
+        let module = Module(name: "Module", sourceFiles: [sourceFile])
+
+        // `class C`
+        let `class` = sourceFile.symbols[0]
+        XCTAssert(`class`.api is Class)
+
+        // `enum E`
+        let `enum` = sourceFile.symbols[1]
+        XCTAssert(`enum`.api is Enumeration)
+
+        let classRelationships = Relationships(of: `class`, in: module)
+        XCTAssertNotEqual(classRelationships.html, "")
+
+        let enumRelationships = Relationships(of: `enum`, in: module)
+        XCTAssertNotEqual(enumRelationships.html, "")
+    }
+
+    func testNoRelationshipsSeciont() throws {
+        let source = #"""
+        public class C {
+        }
+
+        public enum E {
+        }
+        """#
+
+        let url = try temporaryFile(contents: source)
+        let sourceFile = try SourceFile(file: url, relativeTo: url.deletingLastPathComponent())
+        let module = Module(name: "Module", sourceFiles: [sourceFile])
+
+        // `class C`
+        let `class` = sourceFile.symbols[0]
+        XCTAssert(`class`.api is Class)
+
+        // `enum E`
+        let `enum` = sourceFile.symbols[1]
+        XCTAssert(`enum`.api is Enumeration)
+
+        let classRelationships = Relationships(of: `class`, in: module)
+        XCTAssertEqual(classRelationships.html, "")
+
+        let enumRelationships = Relationships(of: `enum`, in: module)
+        XCTAssertEqual(enumRelationships.html, "")
+    }
+
+    #endif
 }

--- a/Tests/SwiftDocTests/NestedTypesTests.swift
+++ b/Tests/SwiftDocTests/NestedTypesTests.swift
@@ -95,7 +95,7 @@ final class NestedTypesTests: XCTestCase {
         XCTAssertNotEqual(enumRelationships.html, "")
     }
 
-    func testNoRelationshipsSeciont() throws {
+    func testNoRelationshipsSection() throws {
         let source = #"""
         public class C {
         }

--- a/Tests/SwiftDocTests/NestedTypesTests.swift
+++ b/Tests/SwiftDocTests/NestedTypesTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+import SwiftDoc
+import SwiftSemantics
+import struct SwiftSemantics.Protocol
+import SwiftSyntax
+
+final class NestedTypesTests: XCTestCase {
+    func testNestedTypes() throws {
+        let source = #"""
+        public class C { }
+
+        extension C {
+            public enum E {
+                case c
+            }
+        }
+
+        extension C.E {
+            public static let tp = 0
+        }
+        """#
+
+        let url = try temporaryFile(contents: source)
+        let sourceFile = try SourceFile(file: url, relativeTo: url.deletingLastPathComponent())
+        let module = Module(name: "Module", sourceFiles: [sourceFile])
+
+        XCTAssertEqual(sourceFile.symbols.count, 4)
+
+        // `class C`
+        let `class` = sourceFile.symbols[0]
+        XCTAssert(`class`.api is Class)
+
+        // `enum E`
+        let `enum` = sourceFile.symbols[1]
+        XCTAssert(`enum`.api is Enumeration)
+
+        // `case c`
+        let `case` = sourceFile.symbols[2]
+        XCTAssert(`case`.api is Enumeration.Case)
+
+        // `let tp`
+        let `let` = sourceFile.symbols[3]
+        XCTAssert(`let`.api is Variable)
+
+        // `class C` contains `enum E`
+        let classRelationships = try XCTUnwrap(module.interface.relationshipsByObject[`class`.id])
+        XCTAssertEqual(classRelationships.count, 1)
+        XCTAssertTrue(classRelationships.allSatisfy({ $0.predicate == .memberOf }))
+        XCTAssertEqual(Set(classRelationships.map({ $0.subject.id })), Set([`enum`.id]))
+
+        // `enum C` contains `case c` and `let tp`
+        let enumRelationships = try XCTUnwrap(module.interface.relationshipsByObject[`enum`.id])
+        XCTAssertEqual(enumRelationships.count, 2)
+        XCTAssertTrue(enumRelationships.allSatisfy({ $0.predicate == .memberOf }))
+        XCTAssertEqual(Set(enumRelationships.map({ $0.subject.id })), Set([`case`.id, `let`.id]))
+
+        // `case c` and `let tp` have no relationships
+        XCTAssertNil(module.interface.relationshipsByObject[`case`.id])
+        XCTAssertNil(module.interface.relationshipsByObject[`let`.id])
+
+        // no other relationships present in module
+        XCTAssertEqual(
+            module.interface.relationships.count,
+            [classRelationships, enumRelationships].joined().count
+        )
+    }
+}


### PR DESCRIPTION
First of all, thanks for a great tool! 🙂

While running swift-doc with one of my current projects, I noticed a bug with nested type handling.

Consider the following input:

```swift
public class Outer { }

extension Outer {
    public enum Inner {
        case Case
    }
}

extension Outer.Inner {
    public static let Ver = 0
}
```

This snippet triggers the following issues:
- `Case` and `Ver` symbols are mistakenly associated with `Outer` symbol
- No "nested types" and "member of" sections are generated