### PR TITLE
Add baseUrl option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `--base-url` option.
+  #65 by @kean.
+
 ## [1.0.0-beta.2] - 2020-04-08
 
 ### Changed

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -29,6 +29,11 @@ extension SwiftDoc {
                     default: .commonmark,
                     help: "The output format")
             var format: Format
+
+            @Option(name: .shortAndLong,
+                    default: "/",
+                    help: "The base URL where the HTML documentation is going to be hosted")
+            var baseUrl: String
         }
 
         static var configuration = CommandConfiguration(abstract: "Generates Swift documentation")
@@ -79,7 +84,7 @@ extension SwiftDoc {
                     }
 
                     let url = outputDirectoryURL.appendingPathComponent(filename)
-                    try page.write(to: url, format: format)
+                    try page.write(to: url, format: format, baseUrl: options.baseUrl)
                 } else {
                     switch format {
                     case .commonmark:
@@ -102,7 +107,7 @@ extension SwiftDoc {
                         }
 
                         let url = outputDirectoryURL.appendingPathComponent(filename)
-                        try $0.value.write(to: url, format: format)
+                        try $0.value.write(to: url, format: format, baseUrl: options.baseUrl)
                     }
                 }
             } catch {

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -32,7 +32,7 @@ extension SwiftDoc {
 
             @Option(name: .customLong("base-url"),
                     default: "/",
-                    help: "The base URL where the HTML documentation is going to be hosted")
+                    help: "The base URL used for all relative URLs in generated documents.")
             var baseURL: String
         }
 

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -33,7 +33,7 @@ extension SwiftDoc {
             @Option(name: .customLong("base-url"),
                     default: "/",
                     help: "The base URL where the HTML documentation is going to be hosted")
-            var baseUrl: String
+            var baseURL: String
         }
 
         static var configuration = CommandConfiguration(abstract: "Generates Swift documentation")
@@ -84,7 +84,7 @@ extension SwiftDoc {
                     }
 
                     let url = outputDirectoryURL.appendingPathComponent(filename)
-                    try page.write(to: url, format: format, baseUrl: options.baseUrl)
+                    try page.write(to: url, format: format, baseURL: options.baseURL)
                 } else {
                     switch format {
                     case .commonmark:
@@ -107,7 +107,7 @@ extension SwiftDoc {
                         }
 
                         let url = outputDirectoryURL.appendingPathComponent(filename)
-                        try $0.value.write(to: url, format: format, baseUrl: options.baseUrl)
+                        try $0.value.write(to: url, format: format, baseURL: options.baseURL)
                     }
                 }
             } catch {

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -30,7 +30,7 @@ extension SwiftDoc {
                     help: "The output format")
             var format: Format
 
-            @Option(name: .shortAndLong,
+            @Option(name: .customLong("base-url"),
                     default: "/",
                     help: "The base URL where the HTML documentation is going to be hosted")
             var baseUrl: String

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -113,7 +113,7 @@ struct Relationships: Component {
                                 """#
                             } else {
                                 return #"""
-                                <dt class="\#(descriptor)"><code><a href="/\#(path(for: symbol))">\#(symbol.id)</a></code></dt>
+                                <dt class="\#(descriptor)"><code><a href="\#(path(for: symbol))">\#(symbol.id)</a></code></dt>
                                 <dd>\#(commonmark: symbol.documentation?.summary ?? "")</dd>
                                 """#
                             }

--- a/Sources/swift-doc/Supporting Types/Helpers.swift
+++ b/Sources/swift-doc/Supporting Types/Helpers.swift
@@ -12,7 +12,7 @@ public func linkCodeElements(of html: String, for symbol: Symbol, in module: Mod
             let candidate = candidates.filter({ $0 != symbol }).first
         {
             let a = Element(name: "a")
-            a["href"] = "/" + path(for: candidate)
+            a["href"] = path(for: candidate)
             element.wrap(inside: a)
         }
     }

--- a/Sources/swift-doc/Supporting Types/Layout.swift
+++ b/Sources/swift-doc/Supporting Types/Layout.swift
@@ -1,7 +1,7 @@
 import HypertextLiteral
 import Foundation
 
-func layout(_ page: Page, baseUrl: String) -> HTML {
+func layout(_ page: Page, baseURL: String) -> HTML {
     let html = page.html
 
     return #"""
@@ -11,14 +11,14 @@ func layout(_ page: Page, baseUrl: String) -> HTML {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>\#(page.module.name) - \#(page.title)</title>
-        <base href="\#(baseUrl)"/>
+        <base href="\#(baseURL)"/>
         <style type="text/css">
         \#(unsafeUnescaped: css)
         </style>
     </head>
     <body>
         <header>
-            <a href="\#(baseUrl)">
+            <a href="\#(baseURL)">
                 <strong>
                     \#(page.module.name)
                 </strong>

--- a/Sources/swift-doc/Supporting Types/Layout.swift
+++ b/Sources/swift-doc/Supporting Types/Layout.swift
@@ -1,7 +1,7 @@
 import HypertextLiteral
 import Foundation
 
-func layout(_ page: Page) -> HTML {
+func layout(_ page: Page, baseUrl: String) -> HTML {
     let html = page.html
 
     return #"""
@@ -11,13 +11,14 @@ func layout(_ page: Page) -> HTML {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>\#(page.module.name) - \#(page.title)</title>
+        <base href="\#(baseUrl)"/>
         <style type="text/css">
         \#(unsafeUnescaped: css)
         </style>
     </head>
     <body>
         <header>
-            <a href="/">
+            <a href="\#(baseUrl)">
                 <strong>
                     \#(page.module.name)
                 </strong>

--- a/Sources/swift-doc/Supporting Types/Page.swift
+++ b/Sources/swift-doc/Supporting Types/Page.swift
@@ -19,13 +19,13 @@ extension Page {
 }
 
 extension Page {
-    func write(to url: URL, format: SwiftDoc.Generate.Format) throws {
+    func write(to url: URL, format: SwiftDoc.Generate.Format, baseUrl: String) throws {
         let data: Data?
         switch format {
         case .commonmark:
             data = document.render(format: .commonmark).data(using: .utf8)
         case .html:
-            data = layout(self).description.data(using: .utf8)
+            data = layout(self, baseUrl: baseUrl).description.data(using: .utf8)
         }
 
         let fileManager = FileManager.default

--- a/Sources/swift-doc/Supporting Types/Page.swift
+++ b/Sources/swift-doc/Supporting Types/Page.swift
@@ -19,13 +19,13 @@ extension Page {
 }
 
 extension Page {
-    func write(to url: URL, format: SwiftDoc.Generate.Format, baseUrl: String) throws {
+    func write(to url: URL, format: SwiftDoc.Generate.Format, baseURL: String) throws {
         let data: Data?
         switch format {
         case .commonmark:
             data = document.render(format: .commonmark).data(using: .utf8)
         case .html:
-            data = layout(self, baseUrl: baseUrl).description.data(using: .utf8)
+            data = layout(self, baseURL: baseURL).description.data(using: .utf8)
         }
 
         let fileManager = FileManager.default


### PR DESCRIPTION
Fixes https://github.com/SwiftDocOrg/swift-doc/issues/56

- Add a new `--base-url` (`baseURL: String`) option
- Update HTML generation to use the new `baseUrl` option
- Update generated links to be relative

Usage:

```
swift doc generate ~/Develop/Nuke/Sources/ \
    --output Documentation \
    --format html \
    --module-name Nuke \
    --base-url https://kean-org.github.io/docs/nuke-docs-beta/9.0.0/
```

## Notes

I made the minimum number of changes needed to make https://kean-org.github.io/docs/nuke-docs-beta/9.0.0/ work. If you don't think this is the right direction, feel free to close it. I'll keep my workaround locally for now.

What I'm not happy about in this solution is that it is not going to work if you browse it locally. Jazzy uses relative URLs in a form of `<a href="../ImageCaching">`. There are two major advantages. It works regardless of how you deploy it (root or not). And it works locally.
