### PR TITLE
Fix crash #78

### DIFF
--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -95,19 +95,19 @@ extension SwiftDoc {
                         pages["Home"] = HomePage(module: module)
                     }
 
-                    try pages.map { $0 }.parallelForEach {
+                    for (name, page) in pages {
                         let filename: String
                         switch format {
                         case .commonmark:
-                            filename = "\($0.key).md"
-                        case .html where $0.key == "Home":
+                            filename = "\(name).md"
+                        case .html where name == "Home":
                             filename = "index.html"
                         case .html:
-                            filename = "\($0.key)/index.html"
+                            filename = "\(name)/index.html"
                         }
 
                         let url = outputDirectoryURL.appendingPathComponent(filename)
-                        try $0.value.write(to: url, format: format, baseURL: options.baseURL)
+                        try page.write(to: url, format: format, baseURL: options.baseURL)
                     }
                 }
             } catch {


### PR DESCRIPTION
Fixes #78.

The root cause is that `Interface` is not thread safe because of all of the lazy properties.

I measured the performance before and after on my project with 68 pages.

Before: **90 ms**.
After: **100 ms**.

This operation could probably be optimized by writing from 2-3 threads, but not from 68 `DispatchQueue.concurrentPerform` iterations. I'm not sure it is worth optimizing it in the first place.
