### PR TITLE
super minor tweak to README & warning emit in generate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #62 by @victor-pavlychko.
 - Fixed rendering of protocol requirements in the HTML version.
   #76 by @victor-pavlychko.
-- Fixed defaulty location of sources reference in README
+- Fixed default location of sources reference in README
   #92 by @heckj
 
 ## [1.0.0-beta.2] - 2020-04-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed README to clarify use of `swift-doc` vs. `swift doc`
   on the command line.
   #89 by @mattt.
+- Changed the generate command to emit a warning if no source
+  files are found.
+  #92 by @heckj
 
 ### Fixed
 
@@ -30,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #62 by @victor-pavlychko.
 - Fixed rendering of protocol requirements in the HTML version.
   #76 by @victor-pavlychko.
+- Fixed defaulty location of sources reference in README
+  #92 by @heckj
 
 ## [1.0.0-beta.2] - 2020-04-08
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed README to clarify use of `swift-doc` vs. `swift doc`
   on the command line.
   #89 by @mattt.
-- Changed the generate command to emit a warning if no source
+- Changed the `generate` command to emit a warning if no source
   files are found.
   #92 by @heckj
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ jobs:
       - name: Generate Documentation
         uses: SwiftDocOrg/swift-doc@master
         with:
-          inputs: "Source"
+          inputs: "Sources"
           module-name: MyLibrary
           output: "Documentation"
       - name: Upload Documentation to Wiki

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -73,7 +73,7 @@ extension SwiftDoc {
         }
 
         guard !pages.isEmpty else {
-            logger.warning("No pages were found to render.")
+            logger.warning("No public API symbols were found at the specified path. No output was written.")
             return
         }
 

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -72,7 +72,10 @@ extension SwiftDoc {
           pages[path(for: name)] = GlobalPage(module: module, name: name, symbols: symbols)
         }
 
-        guard !pages.isEmpty else { return }
+        guard !pages.isEmpty else {
+            logger.warning("No pages were found to render.")
+            return
+        }
 
         if pages.count == 1, let page = pages.first?.value {
           let filename: String


### PR DESCRIPTION
this may be me just being an idiot, but I completely missed `source` vs. `sources` in the README example for using the wiki code generation example, and burned hours hunting it down. For the example, I think it would be awesome if it matched up with the default so that others don't stub their toes on this particular nit.

I also made a minor tweak (separate commit) to emit a warning so that at least some output appears when it fails to find any source files to generate against.

related to #86