### PR TITLE
Reimplement base URL support without <base> tag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `--base-url` option.
-  #65 by @kean.
+  #65 by @kean and #93 by @mattt.
 - Added asset pipeline for CSS assets.
   #49 by @kaishin.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ make install
 
     OVERVIEW: Generates Swift documentation
 
-    USAGE: swift-doc generate [<inputs> ...] --module-name <module-name> [--output <output>] [--format <format>]
+    USAGE: swift-doc generate [<inputs> ...] --module-name <module-name> [--output <output>] [--format <format>] [--base-url <base-url>]
 
     ARGUMENTS:
       <inputs>                One or more paths to Swift files 
@@ -78,6 +78,8 @@ $ make install
       -o, --output <output>   The path for generated output (default:
                               .build/documentation)
       -f, --format <format>   The output format (default: commonmark)
+      --base-url <base-url>   The base URL used for all relative URLs in generated
+                              documents. (default: /)
       -h, --help              Show help information.
 
 The `generate` subcommand 

--- a/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
+++ b/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
@@ -15,10 +15,6 @@ extension Symbol {
         node.height = 0.5
         node.fixedSize = .shape
 
-        if !(api is Unknown) {
-            node.href = "/" + path(for: self)
-        }
-
         switch api {
         case let `class` as Class:
             node.class = "class"
@@ -40,7 +36,7 @@ extension Symbol {
         return node
     }
 
-    func graph(in module: Module) -> Graph {
+    func graph(in module: Module, baseURL: String) -> Graph {
         var graph = Graph(directed: true)
 
         let relationships = module.interface.relationships.filter {
@@ -49,6 +45,11 @@ extension Symbol {
         }
 
         var symbolNode = self.node
+
+        if !(api is Unknown) {
+            symbolNode.href = path(for: self, with: baseURL)
+        }
+
         symbolNode.strokeWidth = 3.0
         symbolNode.class = [symbolNode.class, "current"].compactMap { $0 }.joined(separator: " ")
 

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -57,9 +57,9 @@ extension SwiftDoc {
         for symbol in module.interface.topLevelSymbols.filter({ $0.isPublic }) {
           switch symbol.api {
           case is Class, is Enumeration, is Structure, is Protocol:
-            pages[path(for: symbol, with: baseURL)] = TypePage(module: module, symbol: symbol, baseURL: baseURL)
+            pages[route(for: symbol)] = TypePage(module: module, symbol: symbol, baseURL: baseURL)
           case let `typealias` as Typealias:
-            pages[path(for: `typealias`.name, with: baseURL)] = TypealiasPage(module: module, symbol: symbol, baseURL: baseURL)
+            pages[route(for: `typealias`.name)] = TypealiasPage(module: module, symbol: symbol, baseURL: baseURL)
           case let function as Function where !function.isOperator:
             globals[function.name, default: []] += [symbol]
           case let variable as Variable:
@@ -70,7 +70,7 @@ extension SwiftDoc {
         }
 
         for (name, symbols) in globals {
-            pages[path(for: name, with: baseURL)] = GlobalPage(module: module, name: name, symbols: symbols, baseURL: baseURL)
+            pages[route(for: name)] = GlobalPage(module: module, name: name, symbols: symbols, baseURL: baseURL)
         }
 
         guard !pages.isEmpty else {

--- a/Sources/swift-doc/Supporting Types/Components/Declaration.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Declaration.swift
@@ -9,10 +9,12 @@ import Xcode
 struct Declaration: Component {
     var symbol: Symbol
     var module: Module
+    let baseURL: String
 
-    init(of symbol: Symbol, in module: Module) {
+    init(of symbol: Symbol, in module: Module, baseURL: String) {
         self.symbol = symbol
         self.module = module
+        self.baseURL = baseURL
     }
 
     // MARK: - Component
@@ -27,7 +29,7 @@ struct Declaration: Component {
 
     var html: HypertextLiteral.HTML {
         var html = try! SwiftSyntaxHighlighter.highlight(source: symbol.declaration, using: Xcode.self)
-        html = linkCodeElements(of: html, for: symbol, in: module)
+        html = linkCodeElements(of: html, for: symbol, in: module, with: baseURL)
         return HTML(html)
     }
 }

--- a/Sources/swift-doc/Supporting Types/Components/Documentation.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Documentation.swift
@@ -10,10 +10,12 @@ import Xcode
 struct Documentation: Component {
     var symbol: Symbol
     var module: Module
+    let baseURL: String
 
-    init(for symbol: Symbol, in module: Module) {
+    init(for symbol: Symbol, in module: Module, baseURL: String) {
         self.symbol = symbol
         self.module = module
+        self.baseURL = baseURL
     }
 
     // MARK: - Component
@@ -37,7 +39,7 @@ struct Documentation: Component {
                 Fragment { "\(documentation.summary!)" }
             }
 
-            Declaration(of: symbol, in: module)
+            Declaration(of: symbol, in: module, baseURL: baseURL)
 
             ForEach(in: documentation.discussionParts) { part in
                 if part is SwiftMarkup.Documentation.Callout {
@@ -87,7 +89,7 @@ struct Documentation: Component {
 
         var fragments: [HypertextLiteralConvertible] = []
 
-        fragments.append(Declaration(of: symbol, in: module))
+        fragments.append(Declaration(of: symbol, in: module, baseURL: baseURL))
 
         if let summary = documentation.summary {
             fragments.append(#"""
@@ -111,11 +113,11 @@ struct Documentation: Component {
                             let source = codeBlock.literal
                         {
                             var html = try! SwiftSyntaxHighlighter.highlight(source: source, using: Xcode.self)
-                            html = linkCodeElements(of: html, for: symbol, in: module)
+                            html = linkCodeElements(of: html, for: symbol, in: module, with: baseURL)
                             return HTML(html)
                         } else {
                             var html = (try! CommonMark.Document(part)).render(format: .html, options: [.unsafe])
-                            html = linkCodeElements(of: html, for: symbol, in: module)
+                            html = linkCodeElements(of: html, for: symbol, in: module, with: baseURL)
                             return HTML(html)
                         }
                     } else {

--- a/Sources/swift-doc/Supporting Types/Components/Members.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Members.swift
@@ -7,6 +7,7 @@ import HypertextLiteral
 struct Members: Component {
     var symbol: Symbol
     var module: Module
+    let baseURL: String
 
     var members: [Symbol]
 
@@ -17,9 +18,11 @@ struct Members: Component {
     var methods: [Symbol]
     var genericallyConstrainedMembers: [[GenericRequirement] : [Symbol]]
 
-    init(of symbol: Symbol, in module: Module) {
+    init(of symbol: Symbol, in module: Module, baseURL: String) {
         self.symbol = symbol
         self.module = module
+        self.baseURL = baseURL
+
         self.members = module.interface.members(of: symbol).filter { $0.extension?.genericRequirements.isEmpty != false }
 
         self.typealiases = members.filter { $0.api is Typealias }
@@ -55,7 +58,7 @@ struct Members: Component {
                             Heading {
                                 Code { member.name }
                             }
-                            Documentation(for: member, in: module)
+                            Documentation(for: member, in: module, baseURL: baseURL)
                         }
                     }
                 }
@@ -72,7 +75,7 @@ struct Members: Component {
                             Section {
                                 ForEach(in: members) { member in
                                     Heading { member.name }
-                                    Documentation(for: member, in: module)
+                                    Documentation(for: member, in: module, baseURL: baseURL)
                                 }
                             }
                         }
@@ -97,7 +100,7 @@ struct Members: Component {
                             <h3>
                                 <code>\#(softbreak(member.name))</code>
                             </h3>
-                            \#(Documentation(for: member, in: module).html)
+                            \#(Documentation(for: member, in: module, baseURL: baseURL).html)
                         </div>
                         """#
                     })
@@ -117,7 +120,7 @@ struct Members: Component {
                         \#(members.map { member -> HypertextLiteral.HTML in
                             #"""
                             <h4>\#(softbreak(member.name))</h4>
-                            \#(Documentation(for: member, in: module).html)
+                            \#(Documentation(for: member, in: module, baseURL: baseURL).html)
                             """#
                         })
                     </section>

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -28,16 +28,18 @@ extension StringBuilder {
 struct Relationships: Component {
     var module: Module
     var symbol: Symbol
+    let baseURL: String
     var inheritedTypes: [Symbol]
 
-    init(of symbol: Symbol, in module: Module) {
+    init(of symbol: Symbol, in module: Module, baseURL: String) {
         self.module = module
         self.symbol = symbol
         self.inheritedTypes = module.interface.typesInherited(by: symbol) + module.interface.typesConformed(by: symbol)
+        self.baseURL = baseURL
     }
 
     var graphHTML: HypertextLiteral.HTML? {
-        var graph = symbol.graph(in: module)
+        var graph = symbol.graph(in: module, baseURL: baseURL)
         guard !graph.edges.isEmpty else { return nil }
 
         graph.aspectRatio = 0.125
@@ -80,7 +82,7 @@ struct Relationships: Component {
                         if type.api is Unknown {
                             return "`\(type.id)`"
                         } else {
-                            return "[`\(type.id)`](\(path(for: type)))"
+                    return "[`\(type.id)`](\(path(for: type, with: baseURL)))"
                         }
                     }.joined(separator: ", "))
                     """#
@@ -118,7 +120,7 @@ struct Relationships: Component {
                                 """#
                             } else {
                                 return #"""
-                                <dt class="\#(descriptor)"><code><a href="\#(path(for: symbol))">\#(symbol.id)</a></code></dt>
+                                <dt class="\#(descriptor)"><code><a href="\#(path(for: symbol, with: baseURL))">\#(symbol.id)</a></code></dt>
                                 <dd>\#(commonmark: symbol.documentation?.summary ?? "")</dd>
                                 """#
                             }

--- a/Sources/swift-doc/Supporting Types/Components/Requirements.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Requirements.swift
@@ -7,10 +7,12 @@ import HypertextLiteral
 struct Requirements: Component {
     var symbol: Symbol
     var module: Module
+    let baseURL: String
 
-    init(of symbol: Symbol, in module: Module) {
+    init(of symbol: Symbol, in module: Module, baseURL: String) {
         self.symbol = symbol
         self.module = module
+        self.baseURL = baseURL
     }
 
     var sections: [(title: String, requirements: [Symbol])] {
@@ -31,7 +33,7 @@ struct Requirements: Component {
                     Heading { section.title }
                     ForEach(in: section.requirements) { requirement in
                         Heading { requirement.name }
-                        Documentation(for: requirement, in: module)
+                        Documentation(for: requirement, in: module, baseURL: baseURL)
                     }
                 }
             }
@@ -53,7 +55,7 @@ struct Requirements: Component {
                             <h3>
                                 <code>\#(softbreak(member.name))</code>
                             </h3>
-                            \#(Documentation(for: member, in: module).html)
+                            \#(Documentation(for: member, in: module, baseURL: baseURL).html)
                         </div>
                         """#
                     })

--- a/Sources/swift-doc/Supporting Types/Helpers.swift
+++ b/Sources/swift-doc/Supporting Types/Helpers.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftDoc
 import HTML
 
-public func linkCodeElements(of html: String, for symbol: Symbol, in module: Module) -> String {
+public func linkCodeElements(of html: String, for symbol: Symbol, in module: Module, with baseURL: String) -> String {
     let document = try! Document(string: html.description)!
     for element in document.search(xpath: "//code | //pre/code//span[contains(@class,'type')]") {
         guard let name = element.content else { continue }
@@ -12,7 +12,7 @@ public func linkCodeElements(of html: String, for symbol: Symbol, in module: Mod
             let candidate = candidates.filter({ $0 != symbol }).first
         {
             let a = Element(name: "a")
-            a["href"] = path(for: candidate)
+            a["href"] = path(for: candidate, with: baseURL)
             element.wrap(inside: a)
         }
     }

--- a/Sources/swift-doc/Supporting Types/Layout.swift
+++ b/Sources/swift-doc/Supporting Types/Layout.swift
@@ -11,7 +11,7 @@ func layout(_ page: Page) -> HTML {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>\#(page.module.name) - \#(page.title)</title>
-        <link rel="stylesheet" type="text/css" href="/all.css" media="all" />
+        <link rel="stylesheet" type="text/css" href="\#(path(for: "all.css", with: page.baseURL))" media="all" />
     </head>
     <body>
         <header>

--- a/Sources/swift-doc/Supporting Types/Layout.swift
+++ b/Sources/swift-doc/Supporting Types/Layout.swift
@@ -1,7 +1,7 @@
 import HypertextLiteral
 import Foundation
 
-func layout(_ page: Page, baseURL: String) -> HTML {
+func layout(_ page: Page) -> HTML {
     let html = page.html
 
     return #"""
@@ -11,12 +11,11 @@ func layout(_ page: Page, baseURL: String) -> HTML {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>\#(page.module.name) - \#(page.title)</title>
-        <base href="\#(baseURL)"/>
-        <link rel="stylesheet" type="text/css" href="all.css" media="all" />
+        <link rel="stylesheet" type="text/css" href="/all.css" media="all" />
     </head>
     <body>
         <header>
-            <a href="\#(baseURL)">
+            <a href="\#(page.baseURL)">
                 <strong>
                     \#(page.module.name)
                 </strong>
@@ -45,7 +44,7 @@ func layout(_ page: Page, baseURL: String) -> HTML {
         </main>
 
         <footer>
-            \#(FooterPage().html)
+            \#(FooterPage(baseURL: page.baseURL).html)
         </footer>
     </body>
     </html>

--- a/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
@@ -18,6 +18,12 @@ fileprivate let timestampDateFormatter: DateFormatter = {
 fileprivate let href = "https://github.com/SwiftDocOrg/swift-doc"
 
 struct FooterPage: Page {
+    let baseURL: String
+
+    init(baseURL: String) {
+        self.baseURL = baseURL
+    }
+
     // MARK: - Page
 
     var document: CommonMark.Document {

--- a/Sources/swift-doc/Supporting Types/Pages/GlobalPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/GlobalPage.swift
@@ -7,11 +7,13 @@ struct GlobalPage: Page {
     let module: Module
     let name: String
     let symbols: [Symbol]
+    let baseURL: String
 
-    init(module: Module, name: String, symbols: [Symbol]) {
+    init(module: Module, name: String, symbols: [Symbol], baseURL: String) {
         self.module = module
         self.name = name
         self.symbols = symbols
+        self.baseURL = baseURL
     }
 
     // MARK: - Page
@@ -24,7 +26,7 @@ struct GlobalPage: Page {
         return Document {
             ForEach(in: symbols) { symbol in
                 Heading { symbol.id.description }
-                Documentation(for: symbol, in: module)
+                Documentation(for: symbol, in: module, baseURL: baseURL)
             }
         }
     }
@@ -46,7 +48,7 @@ struct GlobalPage: Page {
         </h1>
 
         \#(symbols.map { symbol in
-        Documentation(for: symbol, in: module).html
+        Documentation(for: symbol, in: module, baseURL: baseURL).html
         })
         """#
     }

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -5,6 +5,7 @@ import HypertextLiteral
 
 struct HomePage: Page {
     var module: Module
+    let baseURL: String
 
     var classes: [Symbol] = []
     var enumerations: [Symbol] = []
@@ -15,8 +16,9 @@ struct HomePage: Page {
     var globalFunctions: [Symbol] = []
     var globalVariables: [Symbol] = []
 
-    init(module: Module) {
+    init(module: Module, baseURL: String) {
         self.module = module
+        self.baseURL = baseURL
 
         for symbol in module.interface.topLevelSymbols.filter({ $0.isPublic }) {
             switch symbol.api {
@@ -69,7 +71,7 @@ struct HomePage: Page {
                 if (!names.isEmpty) {
                     Heading { heading }
                     List(of: names.sorted()) { name in
-                        Link(urlString: path(for: name), text: name)
+                        Link(urlString: path(for: name, with: baseURL), text: name)
                     }
                 }
             }
@@ -90,7 +92,7 @@ struct HomePage: Page {
                           Heading { heading }
                             
                           List(of: names.sorted()) { name in
-                            Link(urlString: path(for: name), text: softbreak(name))
+                            Link(urlString: path(for: name, with: baseURL), text: softbreak(name))
                           }
                         }
                     }
@@ -163,7 +165,7 @@ struct HomePage: Page {
             let descriptor = String(describing: type(of: symbol.api)).lowercased()
             return #"""
             <dt class="\#(descriptor)">
-                <a href=\#(path(for: symbol)) title="\#(descriptor) - \#(symbol.id.description)">
+                <a href=\#(path(for: symbol, with: baseURL)) title="\#(descriptor) - \#(symbol.id.description)">
                     \#(softbreak(symbol.id.description))
                 </a>
             </dt>

--- a/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
@@ -5,6 +5,7 @@ import HypertextLiteral
 
 struct SidebarPage: Page {
     var module: Module
+    let baseURL: String
 
     var typeNames: Set<String> = []
     var protocolNames: Set<String> = []
@@ -13,8 +14,9 @@ struct SidebarPage: Page {
     var globalFunctionNames: Set<String> = []
     var globalVariableNames: Set<String> = []
 
-    init(module: Module) {
+    init(module: Module, baseURL: String) {
         self.module = module
+        self.baseURL = baseURL
 
         for symbol in module.interface.topLevelSymbols.filter({ $0.isPublic }) {
             switch symbol.api {
@@ -65,7 +67,7 @@ struct SidebarPage: Page {
                 }
 
                 List(of: section.names.sorted()) { name in
-                    Link(urlString: "/" + path(for: name), text: name)
+                    Link(urlString: path(for: name, with: baseURL), text: name)
                 }
 
                 Fragment { "</details>" }

--- a/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
@@ -6,11 +6,13 @@ import HypertextLiteral
 struct TypePage: Page {
     let module: Module
     let symbol: Symbol
+    let baseURL: String
 
-    init(module: Module, symbol: Symbol) {
+    init(module: Module, symbol: Symbol, baseURL: String) {
         precondition(symbol.api is Type)
         self.module = module
         self.symbol = symbol
+        self.baseURL = baseURL
     }
 
     // MARK: - Page
@@ -23,10 +25,10 @@ struct TypePage: Page {
         return CommonMark.Document {
             Heading { symbol.id.description }
 
-            Documentation(for: symbol, in: module)
-            Relationships(of: symbol, in: module)
-            Members(of: symbol, in: module)
-            Requirements(of: symbol, in: module)
+            Documentation(for: symbol, in: module, baseURL: baseURL)
+            Relationships(of: symbol, in: module, baseURL: baseURL)
+            Members(of: symbol, in: module, baseURL: baseURL)
+            Requirements(of: symbol, in: module, baseURL: baseURL)
         }
     }
 
@@ -37,10 +39,10 @@ struct TypePage: Page {
             <code class="name">\#(softbreak(symbol.id.description))</code>
         </h1>
 
-        \#(Documentation(for: symbol, in: module).html)
-        \#(Relationships(of: symbol, in: module).html)
-        \#(Members(of: symbol, in: module).html)
-        \#(Requirements(of: symbol, in: module).html)
+        \#(Documentation(for: symbol, in: module, baseURL: baseURL).html)
+        \#(Relationships(of: symbol, in: module, baseURL: baseURL).html)
+        \#(Members(of: symbol, in: module, baseURL: baseURL).html)
+        \#(Requirements(of: symbol, in: module, baseURL: baseURL).html)
         """#
     }
 }

--- a/Sources/swift-doc/Supporting Types/Pages/TypealiasPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypealiasPage.swift
@@ -6,11 +6,13 @@ import HypertextLiteral
 struct TypealiasPage: Page {
     let module: Module
     let symbol: Symbol
+    let baseURL: String
 
-    init(module: Module, symbol: Symbol) {
+    init(module: Module, symbol: Symbol, baseURL: String) {
         precondition(symbol.api is Typealias)
         self.module = module
         self.symbol = symbol
+        self.baseURL = baseURL
     }
 
     // MARK: - Page
@@ -22,7 +24,7 @@ struct TypealiasPage: Page {
     var document: CommonMark.Document {
         Document {
             Heading { symbol.id.description }
-            Documentation(for: symbol, in: module)
+            Documentation(for: symbol, in: module, baseURL: baseURL)
         }
     }
 
@@ -33,7 +35,7 @@ struct TypealiasPage: Page {
             <span class="name">\#(softbreak(symbol.id.description))</span>
         </h1>
 
-        \#(Documentation(for: symbol, in: module).html)
+        \#(Documentation(for: symbol, in: module, baseURL: baseURL).html)
         """#
     }
 }


### PR DESCRIPTION
This PR seeks to reimplement base URL support added in #65 based on feedback from #82. With my sincere apologies to @kean for leading him down the wrong path by advocating for `<base>` without being aware of its limitations.

I fully acknowledge the jankiness of this approach. Tacking on parameters all over the place like this is unsustainable, but I want to get a fix out sooner rather than later. Long-term, this is the kind of configuration I'd like to encapsulate by a `Generator` (#67)