### PR TITLE
Fix link to CSS in default HTML output

### DIFF
--- a/Sources/swift-doc/Supporting Types/Layout.swift
+++ b/Sources/swift-doc/Supporting Types/Layout.swift
@@ -11,8 +11,8 @@ func layout(_ page: Page, baseURL: String) -> HTML {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>\#(page.module.name) - \#(page.title)</title>
-        <base href="\#(baseURL)"/>
         <link rel="stylesheet" type="text/css" href="all.css" media="all" />
+        <base href="\#(baseURL)"/>
     </head>
     <body>
         <header>


### PR DESCRIPTION
This ensures `all.css` is visible by the HTML file before the base URL is set, and fixes https://github.com/SwiftDocOrg/swift-doc/issues/95.

This was the most minimal change I could think of to get this to work, but another option could be to change the default `base-url` argument from `"/"` to just an empty string `""` - let me know if that is preferred and I can make that change.