### PR TITLE
Include symbol summaries on Home page in CommonMark format

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "CommonMark",
         "repositoryURL": "https://github.com/SwiftDocOrg/CommonMark.git",
         "state": {
-          "branch": "master",
-          "revision": "00d3a8ce879b6578979a3470430867f85af26b92",
-          "version": null
+          "branch": null,
+          "revision": "62176a332884826997928ba578d9d322c16772fb",
+          "version": "0.4.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/Markup.git",
         "state": {
           "branch": null,
-          "revision": "9a429d0011d738059bc94f5f92ee406689597a91",
-          "version": "0.0.3"
+          "revision": "029ad8c1115ab32b7c20ab52eb092fbc030deb17",
+          "version": "0.0.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/swift-cmark.git",
         "state": {
           "branch": null,
-          "revision": "1168665f6b36be747ffe6b7b90bc54cfc17f42b7",
-          "version": "0.28.3+20200207.1168665"
+          "revision": "2a766030bee955b4806044fd7aca1b6884475138",
+          "version": "0.28.3+20200110.2a76603"
         }
       },
       {
@@ -95,9 +95,9 @@
         "package": "SwiftMarkup",
         "repositoryURL": "https://github.com/SwiftDocOrg/SwiftMarkup.git",
         "state": {
-          "branch": null,
-          "revision": "431f418ae1833a312646e934a2891e778c1b03b0",
-          "version": "0.0.5"
+          "branch": "0.2.0",
+          "revision": "f395f3bd9e345402cc744aa9051780ed403d3b26",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/CommonMark.git",
         "state": {
           "branch": null,
-          "revision": "62176a332884826997928ba578d9d322c16772fb",
-          "version": "0.4.0"
+          "revision": "902cc82abc2e8ad23b73c982eed27c63ae3d9384",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", .revision("0.50200.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .branch("master")),
-        .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.0.5")),
+        .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .revision("0.2.0")),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .revision("03405c13dc1c31f50c08bbec6e7587cbee1c7fb3")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
         .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.0.3")),

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", .revision("0.50200.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .revision("902cc82abc2e8ad23b73c982eed27c63ae3d9384")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .revision("0.2.0")),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .revision("03405c13dc1c31f50c08bbec6e7587cbee1c7fb3")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),

--- a/Sources/swift-doc/Supporting Types/Components/Abstract.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Abstract.swift
@@ -1,0 +1,55 @@
+import CommonMarkBuilder
+import SwiftDoc
+import SwiftMarkup
+import SwiftSemantics
+import HypertextLiteral
+
+struct Abstract: Component {
+    var symbol: Symbol
+
+    init(for symbol: Symbol) {
+        self.symbol = symbol
+    }
+    
+    // MARK: - Component
+
+    var fragment: Fragment {
+        if let summary = symbol.documentation?.summary {
+            return Fragment {
+                List.Item {
+                    Paragraph {
+                        Link(urlString: path(for: symbol), text: symbol.id.description)
+                        Text { ":" }
+                    }
+
+                    Fragment {
+                        summary
+                    }
+                }
+            }
+        } else {
+            return Fragment {
+                List.Item {
+                    Paragraph {
+                        Link(urlString: path(for: symbol), text: symbol.id.description)
+                    }
+                }
+            }
+        }
+    }
+
+    var html: HypertextLiteral.HTML {
+        let descriptor = String(describing: type(of: symbol.api)).lowercased()
+
+        return #"""
+        <dt class="\#(descriptor)">
+            <a href=\#(path(for: symbol)) title="\#(descriptor) - \#(symbol.id.description)">
+                \#(softbreak(symbol.id.description))
+            </a>
+        </dt>
+        <dd>
+            \#(commonmark: symbol.documentation?.summary ?? "")
+        </dd>
+        """#
+    }
+}

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -63,11 +63,8 @@ struct HomePage: Page {
                 if (!symbols.isEmpty) {
                     Heading { heading }
 
-                    // FIXME: HTMLBlock doesn't render for some reason
-                    Paragraph {
-                        RawHTML {
-                            listHTML(symbols: symbols).description
-                        }
+                    List(of: symbols.sorted()) { symbol in
+                        Abstract(for: symbol).fragment
                     }
                 }
             }
@@ -81,73 +78,21 @@ struct HomePage: Page {
             ("Structures", structures),
             ("Enumerations", enumerations),
             ("Protocols", protocols),
+            ("Typealiases", globalTypealiases),
+            ("Functions", globalFunctions),
+            ("Variables", globalVariables)
         ].compactMap { (heading, symbols) -> HypertextLiteral.HTML? in
             guard !symbols.isEmpty else { return nil }
 
             return #"""
             <section id=\#(heading.lowercased())>
                 <h2>\#(heading)</h2>
-                \#(listHTML(symbols: symbols))
+                <dl>
+                    \#(symbols.sorted().map { Abstract(for: $0).html })
+                </dl>
             </section>
         """#
         })
-        \#(globalsHTML)
-        """#
-    }
-
-    private var globalsHTML: HypertextLiteral.HTML {
-        guard !globalTypealiases.isEmpty ||
-            !globalFunctions.isEmpty ||
-            !globalVariables.isEmpty else {
-                return ""
-        }
-
-        let heading = "Globals"
-        return #"""
-        <section id=\#(heading.lowercased())>
-            <h2>\#(heading)</h2>
-            \#(globalsListHTML)
-        </section>
-        """#
-    }
-
-    private var globalsListHTML: HypertextLiteral.HTML {
-        let globals = [
-            ("Typealiases", globalTypealiases),
-            ("Functions", globalFunctions),
-            ("Variables", globalVariables),
-        ]
-        return #"""
-        \#(globals.compactMap { (heading, symbols) -> HypertextLiteral.HTML? in
-            guard !symbols.isEmpty else { return nil }
-
-            return #"""
-            <section id=\#(heading.lowercased())>
-                <h3>\#(heading)</h3>
-                \#(listHTML(symbols: symbols))
-            </section>
-        """#
-        })
-        """#
-    }
-
-    private func listHTML(symbols: [Symbol]) -> HypertextLiteral.HTML {
-        #"""
-        <dl>
-            \#(symbols.sorted().map { symbol ->  HypertextLiteral.HTML in
-            let descriptor = String(describing: type(of: symbol.api)).lowercased()
-            return #"""
-            <dt class="\#(descriptor)">
-                <a href=\#(path(for: symbol)) title="\#(descriptor) - \#(symbol.id.description)">
-                    \#(softbreak(symbol.id.description))
-                </a>
-            </dt>
-            <dd>
-                \#(commonmark: symbol.documentation?.summary ?? "")
-            </dd>
-            """#
-            })
-        </dl>
         """#
     }
 }

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -11,7 +11,7 @@ struct HomePage: Page {
     var structures: [Symbol] = []
     var protocols: [Symbol] = []
     var operators: [Symbol] = []
-    var globalTypealias: [Symbol] = []
+    var globalTypealiases: [Symbol] = []
     var globalFunctions: [Symbol] = []
     var globalVariables: [Symbol] = []
 
@@ -29,7 +29,7 @@ struct HomePage: Page {
             case is Protocol:
                 protocols.append(symbol)
             case is Typealias:
-                globalTypealias.append(symbol)
+                globalTypealiases.append(symbol)
             case is Operator:
                 operators.append(symbol)
             case let function as Function where function.isOperator:
@@ -51,47 +51,22 @@ struct HomePage: Page {
     }
 
     var document: CommonMark.Document {
-        let types = classes + enumerations + structures
-        let typeNames = Set(types.map { $0.id.description })
-        let protocolNames = Set(protocols.map { $0.id.description })
-        let operatorNames = Set(operators.map { $0.id.description })
-
-        let globalTypealiasNames = Set(globalTypealias.map { $0.id.description })
-        let globalFunctionNames = Set(globalFunctions.map { $0.id.description })
-        let globalVariableNames = Set(globalVariables.map { $0.id.description })
-
         return Document {
             ForEach(in: [
-                ("Types", typeNames),
-                ("Protocols", protocolNames),
-                ("Operators", operatorNames)
-            ]) { (heading, names) in
-                if (!names.isEmpty) {
+                ("Types", classes + enumerations + structures),
+                ("Protocols", protocols),
+                ("Operators", operators),
+                ("Global Typealiases", globalTypealiases),
+                ("Global Functions", globalFunctions),
+                ("Global Variables", globalVariables),
+            ]) { (heading, symbols) in
+                if (!symbols.isEmpty) {
                     Heading { heading }
-                    List(of: names.sorted()) { name in
-                        Link(urlString: path(for: name), text: name)
-                    }
-                }
-            }
 
-            if !globalTypealiasNames.isEmpty ||
-                !globalFunctionNames.isEmpty ||
-                !globalVariableNames.isEmpty
-            {
-                Heading { "Globals" }
-
-                Section {
-                    ForEach(in: [
-                          ("Typealiases", globalTypealiasNames),
-                          ("Functions", globalFunctionNames),
-                          ("Variables", globalVariableNames)
-                      ]) { (heading, names) in
-                        if (!names.isEmpty) {
-                          Heading { heading }
-                            
-                          List(of: names.sorted()) { name in
-                            Link(urlString: path(for: name), text: softbreak(name))
-                          }
+                    // FIXME: HTMLBlock doesn't render for some reason
+                    Paragraph {
+                        RawHTML {
+                            listHTML(symbols: symbols).description
                         }
                     }
                 }
@@ -121,7 +96,7 @@ struct HomePage: Page {
     }
 
     private var globalsHTML: HypertextLiteral.HTML {
-        guard !globalTypealias.isEmpty ||
+        guard !globalTypealiases.isEmpty ||
             !globalFunctions.isEmpty ||
             !globalVariables.isEmpty else {
                 return ""
@@ -138,7 +113,7 @@ struct HomePage: Page {
 
     private var globalsListHTML: HypertextLiteral.HTML {
         let globals = [
-            ("Typealiases", globalTypealias),
+            ("Typealiases", globalTypealiases),
             ("Functions", globalFunctions),
             ("Variables", globalVariables),
         ]


### PR DESCRIPTION
The current version of the Home pages links to each top-level symbol in a bulleted list, with only the symbol's (qualified) name provided. This presentation isn't very information-dense or informative at all.

This PR offers an alternative take that includes quick summaries alongside each symbol. Here's a look of what that looks like for Alamofire:

- [Before](https://github.com/SwiftDocOrg/Alamofire/wiki/Home/3b49cc44e104707d6f9c432cc60c4e1aaa2254a3)
- [After](https://github.com/SwiftDocOrg/Alamofire/wiki/Home/edb99034ceeb198818c5c64ffa639c15c253f295)

This implementation replaces the bulleted list with a definition list. Because those aren't supported in CommonMark (or [GitHub Flavored Markdown](https://github.github.com/gfm/)), it uses raw HTML (`<dl>` / `<dt>` / `<dd>`) tags. However, this isn't a necessary change; if we decide to keep CommonMark output format relatively free of HTML, we could certainly reimplement with a bulleted list instead.