### PR TITLE
Log warning message when failing to generate graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ as well as top-level type aliases, functions, and variables.
 ## Requirements
 
 - Swift 5.2
+- [GraphViz][graphviz] _(optional)_
 
 ## Command-Line Utility
 

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -49,7 +49,7 @@ struct Relationships: Component {
         do {
             return try HypertextLiteral.HTML(String(data: graph.render(using: algorithm, to: .svg), encoding: .utf8) ?? "")
         } catch {
-            logger.error("\(error)")
+            logger.warning("Failed to generate relationship graph for \(symbol.id). Please ensure that GraphViz binaries are accessible from your PATH. (\(error))")
             return nil
         }
     }


### PR DESCRIPTION
Resolves #48 

As of #52, we log any errors caught during graph generation:

```
2020-05-06T12:00:00-0700 error: Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"
```

Although this involves error handling, the `error` log level is inappropriate here, because the failure isn't critical. Documentation may be generated even if GraphViz graphs aren't available.

This PR changes the log level to `warning` and wraps the raw `NSError` with some more actionable information:

```
2020-05-06T12:00:00-0700 warning: Failed to generate relationship graph for _____________. Please ensure that GraphViz binaries are accessible from your PATH. (Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied")
```

I was able to reproduce #52 locally by running `brew unlink graphviz`. Since [the formula for `swift-doc`](https://github.com/SwiftDocOrg/homebrew-formulae/blob/master/Formula/swift-doc.rb) now includes GraphViz as an (optional) dependency, this is much less likely to occur going forward.