### PR TITLE
fix #134: crash for operator functions when no baseURL.

### DIFF
--- a/Sources/swift-doc/Supporting Types/Page.swift
+++ b/Sources/swift-doc/Supporting Types/Page.swift
@@ -48,9 +48,8 @@ func path(for symbol: Symbol, with baseURL: String) -> String {
 }
 
 func path(for identifier: CustomStringConvertible, with baseURL: String) -> String {
-    var urlComponents = URLComponents(string: baseURL)
-    urlComponents = urlComponents?.appendingPathComponent("\(identifier)")
-    guard let string = urlComponents?.string else {
+    let url = URL(string: baseURL)?.appendingPathComponent("\(identifier)")
+    guard let string = url?.path else {
         logger.critical("Unable to construct path for \(identifier) with baseURL \(baseURL)")
         fatalError()
     }
@@ -64,17 +63,4 @@ func writeFile(_ data: Data, to url: URL) throws {
 
     try data.write(to: url)
     try fileManager.setAttributes([.posixPermissions: 0o744], ofItemAtPath: url.path)
-}
-
-// MARK: -
-
-fileprivate extension URLComponents {
-    func appendingPathComponent(_ component: String) -> URLComponents? {
-        var urlComponents = self
-        var pathComponents = urlComponents.path.split(separator: "/").map { "\($0)" }
-        pathComponents.append(component)
-        urlComponents.path = "/" + pathComponents.joined(separator: "/")
-
-        return urlComponents
-    }
 }


### PR DESCRIPTION
Fixes crashes like this one:

```bash
$ swift doc generate my-repo/Sources --module-name MyRepo
2020-06-30T17:00:13-0400 critical: Unable to construct path for /(lhs:rhs:) with baseURL /
Fatal error: file /private/tmp/swift-doc-20200630-24417-jrxtfw/Sources/swift-doc/Supporting Types/Page.swift, line 55
zsh: illegal hardware instruction  swift doc generate my-repo/Sources --module-name MyRepo
```

See caveat at https://github.com/SwiftDocOrg/swift-doc/issues/134#issuecomment-653904519