### PR TITLE
Fix markup for parameter descriptions in HTML output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed regression that caused nodes in relationships graph
   to not have links to their corresponding symbol documentation.
   #153 by @mattt.
+- Fixed markup for parameter descriptions in HTML output.
+  #156 by @mattt.
 
 ## [1.0.0-beta.3] - 2020-05-19
 

--- a/Sources/swift-doc/Supporting Types/Components/Documentation.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Documentation.swift
@@ -119,7 +119,7 @@ struct Documentation: Component {
                     type = nil
                 }
 
-                return (entry.name, type, entry.description)
+                return (entry.name, type, entry.content)
             }
 
             fragments.append(#"""

--- a/Sources/swift-doc/Supporting Types/Components/Documentation.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Documentation.swift
@@ -145,7 +145,7 @@ struct Documentation: Component {
                       return #"""
                       <tr>
                           <th>\#(softbreak(entry.name))</th>
-                          \#(typeCell)</td>
+                          \#(typeCell)
                           <td>\#(commonmark: entry.description)</td>
                       </tr>
                       """# as HypertextLiteral.HTML


### PR DESCRIPTION
Resolves #155 

**Before**

<img width="868" alt="Screen Shot 2020-07-31 at 12 04 50" src="https://user-images.githubusercontent.com/7659/89073580-a564ed00-d32f-11ea-8ad4-b0a52915743d.png">

**After**

<img width="839" alt="Screen Shot 2020-07-31 at 13 12 36" src="https://user-images.githubusercontent.com/7659/89073596-ac8bfb00-d32f-11ea-8cfc-830909003dd6.png">
