### PR TITLE
Update version constant for swift-doc command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed version number for swift-doc command.
+  #159 by @mattt.
+
 ## [1.0.0-beta.4] - 2020-07-31
 
 ### Added

--- a/Sources/swift-doc/main.swift
+++ b/Sources/swift-doc/main.swift
@@ -22,7 +22,7 @@ struct SwiftDoc: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "swift doc",
         abstract: "A utility for generating documentation for Swift code.",
-        version: "1.0.0-beta.3",
+        version: "1.0.0-beta.4",
         subcommands: [Generate.self, Coverage.self, Diagram.self]
     )
 }


### PR DESCRIPTION
Because of course manual release processes are error-prone.