### PR TITLE
Use .gv file extension for GraphViz DOT output

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ generates a graph of APIs in [DOT format][dot]
 that can be rendered by [GraphViz][graphviz] into a diagram.
 
 ```terminal
-$ swift run swift-doc diagram Alamofire/Source > graph.dot
-$ head graph.dot
+$ swift run swift-doc diagram Alamofire/Source > Alamofire.gv
+$ head Alamofire.gv
 digraph Anonymous {
   "Session" [shape=box];
   "NetworkReachabilityManager" [shape=box];
@@ -190,7 +190,7 @@ digraph Anonymous {
     "DataRequest" [shape=box];
     "Request" [shape=box];
 
-$ dot -T svg graph.dot > graph.svg
+$ dot -T svg Alamofire.gv > Alamofire.svg
 ```
 
 Here's an excerpt of the graph generated for Alamofire:


### PR DESCRIPTION
As discussed in [this thread](https://forum.graphviz.org/t/bison-switching-to-gv-graphviz-output/274) on the GraphViz forums:

> [Bison](https://www.gnu.org/software/bison/) 3.7 was recently released, with the accompanying release notes containing this snippet:
> 
>> In conformance with the recommendations of the Graphviz team, in the next
>> version Bison the option `--graph` will generate a *.gv file by default,
>> instead of *.dot. A transition started in Bison 3.4.
> 
> I thought this was interesting because (1) I had no idea Bison could generate Graphviz and (2) I did not realize .gv was preferred over .dot. Maybe these are widely known to others.
> 
> The recommendation seems to have come on [a mailing list thread ](https://lists.gnu.org/archive/html/help-bison/2019-02/msg00037.html), pointing to [a Wikipedia page ](https://en.wikipedia.org/wiki/DOT_(graph_description_language)), pointing to [Emden’s recommendation in 2011 ](https://marc.info/?l=graphviz-devel&m=129418103126092).