### PR TITLE
Fix Markdown listing of function parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed listing of function parameters, when generating CommonMark documentation.
+  #170 by @domcorvasce.
+
 - Fixed version number for swift-doc command.
   #159 by @mattt.
 

--- a/Sources/swift-doc/Supporting Types/Components/Documentation.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Documentation.swift
@@ -49,7 +49,7 @@ struct Documentation: Component {
                 Section {
                     Heading { "Parameters" }
                     List(of:  documentation.parameters) { parameter in
-                        Fragment { "\(parameter.name): \(parameter.description)" }
+                        Fragment { "\(parameter.name): \(parameter.content)" }
                     }
                 }
             }


### PR DESCRIPTION
Resolves #170 

**It's my first time diving into SwiftDoc codebase. Excuse me if I say something wrong.**

The code which list parameters is at`swift-doc/Supporting Types/Components/Documentation.swift:52`.

```swift
List(of:  documentation.parameters) { parameter in
    Fragment { "\(parameter.name): \(parameter.description)" }
}
```

`Parameter#description` returns a string representation of the object, which includes the name and `-`.
I didn't look further into it, but obviously we were repeating the parameter name and adding an additional dash.

In the end, I replaced `parameter.description` with `parameter.content` (thanks to `Documentation.swift:122`).
It works now.