### PR TITLE
Don't render href on nodes for unknown symbols for child relationships

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed listing of function parameters, when generating CommonMark documentation.
   #170 by @domcorvasce.
-
 - Fixed version number for swift-doc command.
   #159 by @mattt.
+- Fixed relationship diagram to prevent linking to unknown symbols.
+  #178 by @MattKiazyk.
 
 ## [1.0.0-beta.4] - 2020-07-31
 

--- a/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
+++ b/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
@@ -60,7 +60,10 @@ extension Symbol {
         for symbol in Set(relationships.flatMap { [$0.subject, $0.object] }) {
             guard self != symbol else { continue }
             var node = symbol.node
-            node.href = path(for: symbol, with: baseURL)
+
+            if !(symbol.api is Unknown) {
+                node.href = path(for: symbol, with: baseURL)
+            }
             graph.append(node)
         }
 


### PR DESCRIPTION
When rendering the GraphViz diagram, when a symbol has a relationship of an `Unknown` type, the code was still rendering those with `href` attributes, causing links be created to invalid links.

A check was added on the base node for `Unknown` types, however no check was added to the relationship loop. This PR adds that.

**Before:** 

<img width="838" alt="Screen Shot 2020-09-04 at 9 22 49 AM" src="https://user-images.githubusercontent.com/1119565/92249920-6bd45400-ee90-11ea-910f-7b3965401909.png">


**After: **
<img width="917" alt="Screen Shot 2020-09-04 at 9 13 15 AM" src="https://user-images.githubusercontent.com/1119565/92249661-0f713480-ee90-11ea-9e75-8134765a9a31.png">


