### PR TITLE
Add graphviz in Dockerfile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed missing GraphViz dependency in Dockerfile.
+  #180 by @MaxDesiatov.
 - Fixed listing of function parameters, when generating CommonMark documentation.
   #170 by @domcorvasce.
-
 - Fixed version number for swift-doc command.
   #159 by @mattt.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
 RUN make install prefix=/build
 
 FROM ubuntu:18.04
-RUN apt-get -qq update && apt-get install -y libatomic1 libxml2-dev libcurl4-openssl-dev && rm -r /var/lib/apt/lists/*
+RUN apt-get -qq update && apt-get install -y graphviz libatomic1 libxml2-dev libcurl4-openssl-dev && rm -r /var/lib/apt/lists/*
 COPY --from=builder /build/bin/swift-doc /usr/bin
 COPY --from=builder /build/lib/* /usr/lib/
 ENTRYPOINT ["swift-doc"]


### PR DESCRIPTION
`graphviz` is not currently installed, which triggers warnings when running the corresponding GitHub Action.