### PR TITLE
Test with Swift 5.3 on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,12 @@ jobs:
   linux:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        swift: ["5.3", "5.2"]
+
     container:
-      image: swift:5.3
+      image: swift:${{ matrix.swift }}
 
     steps:
       - name: Checkout
@@ -36,9 +40,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-spm-swift-${{ matrix.swift }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-swift-${{ matrix.swift }}-
       - name: Install System Dependencies
         run: |
           apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   macos:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     strategy:
       matrix:
-        xcode: ["12", "11.4"]
+        xcode:
+          - "11.7" # Swift 5.2
+          - "12" # Swift 5.3
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: swift:5.2
+      image: swift:5.3
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,23 @@ jobs:
   macos:
     runs-on: macOS-latest
 
+    strategy:
+      matrix:
+        xcode: ["12", "11.4"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - uses: actions/cache@v2
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-
       - name: Build and Test
         run: swift test -c release
         env:
-          DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
   linux:
     runs-on: ubuntu-latest

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Swift 5.3.
+  #183 by @MaxDesiatov and @mattt.
+
 ### Fixed
 
 - Fixed missing GraphViz dependency in Dockerfile.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -10,24 +10,37 @@ let package = Package(
         .library(name: "SwiftDoc", targets: ["SwiftDoc"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .revision("0.50200.0")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("0.50300.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.4.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.2.1")),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.1.2")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
         .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.0.3")),
-        .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.0.0")),
+        .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.1.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.6")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.2.0")),
-        .package(url: "https://github.com/NSHipster/swift-log-github-actions.git", .upToNextMinor(from: "0.0.1")),
+        .package(name: "LoggingGitHubActions", url: "https://github.com/NSHipster/swift-log-github-actions.git", .upToNextMinor(from: "0.0.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "swift-doc",
-            dependencies: ["ArgumentParser", "SwiftDoc", "SwiftSemantics", "SwiftMarkup", "CommonMarkBuilder", "HypertextLiteral", "Markup", "DCOV", "GraphViz", "SwiftSyntaxHighlighter", "Logging", "LoggingGitHubActions"]
+            dependencies: [
+                .target(name: "SwiftDoc"),
+                .target(name: "DCOV"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SwiftSemantics", package: "SwiftSemantics"),
+                .product(name: "SwiftMarkup", package: "SwiftMarkup"),
+                .product(name: "CommonMarkBuilder", package: "CommonMark"),
+                .product(name: "HypertextLiteral", package: "HypertextLiteral"),
+                .product(name: "Markup", package: "Markup"),
+                .product(name: "GraphViz", package: "GraphViz"),
+                .product(name: "SwiftSyntaxHighlighter", package: "SwiftSyntaxHighlighter"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "LoggingGitHubActions", package: "LoggingGitHubActions")
+            ]
         ),
         .target(
             name: "DCOV",
@@ -35,11 +48,20 @@ let package = Package(
         ),
         .target(
             name: "SwiftDoc",
-            dependencies: ["SwiftSyntax", "SwiftSemantics", "SwiftMarkup"]
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+                .product(name: "SwiftSemantics", package: "SwiftSemantics"),
+                .product(name: "SwiftMarkup", package: "SwiftMarkup")
+            ]
         ),
         .testTarget(
             name: "SwiftDocTests",
-            dependencies: ["SwiftDoc", "SwiftSyntax", "SwiftSemantics", "SwiftMarkup"]
+            dependencies: [
+                .target(name: "SwiftDoc"),
+                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+                .product(name: "SwiftSemantics", package: "SwiftSemantics"),
+                .product(name: "SwiftMarkup", package: "SwiftMarkup")
+            ]
         ),
     ]
 )

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,0 +1,45 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-doc",
+    products: [
+        .executable(name: "swift-doc", targets: ["swift-doc"]),
+        .library(name: "SwiftDoc", targets: ["SwiftDoc"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-syntax.git", .revision("0.50200.0")),
+        .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.2.1")),
+        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.1.2")),
+        .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
+        .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.0.3")),
+        .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.0.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.6")),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.2.0")),
+        .package(url: "https://github.com/NSHipster/swift-log-github-actions.git", .upToNextMinor(from: "0.0.1")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "swift-doc",
+            dependencies: ["ArgumentParser", "SwiftDoc", "SwiftSemantics", "SwiftMarkup", "CommonMarkBuilder", "HypertextLiteral", "Markup", "DCOV", "GraphViz", "SwiftSyntaxHighlighter", "Logging", "LoggingGitHubActions"]
+        ),
+        .target(
+            name: "DCOV",
+            dependencies: []
+        ),
+        .target(
+            name: "SwiftDoc",
+            dependencies: ["SwiftSyntax", "SwiftSemantics", "SwiftMarkup"]
+        ),
+        .testTarget(
+            name: "SwiftDocTests",
+            dependencies: ["SwiftDoc", "SwiftSyntax", "SwiftSemantics", "SwiftMarkup"]
+        ),
+    ]
+)


### PR DESCRIPTION
I'm not sure if you'd like to test with both Swift 5.2 and 5.3 on Linux. As you're using a cache, I think it would be easier to test just with a single version, as it doesn't make sense to share that cache. Let me know if you'd prefer to test both versions after all with separate cache keys.