### PR TITLE
Supply a prebuilt image in Dockerfile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Supply a prebuilt image in Dockerfile.
+  #184 by @MaxDesiatov.
 - Fixed missing GraphViz dependency in Dockerfile.
   #180 by @MaxDesiatov.
 - Fixed listing of function parameters, when generating CommonMark documentation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,1 @@
-FROM swift:5.2 as builder
-WORKDIR /swiftdoc
-COPY . .
-RUN apt-get -qq update && apt-get install -y libxml2-dev && rm -r /var/lib/apt/lists/*
-RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
-RUN make install prefix=/build
-
-FROM ubuntu:18.04
-RUN apt-get -qq update && apt-get install -y graphviz libatomic1 libxml2-dev libcurl4-openssl-dev && rm -r /var/lib/apt/lists/*
-COPY --from=builder /build/bin/swift-doc /usr/bin
-COPY --from=builder /build/lib/* /usr/lib/
-ENTRYPOINT ["swift-doc"]
-CMD ["--help"]
+FROM swiftdoc/swift-doc:latest

--- a/prebuilt.Dockerfile
+++ b/prebuilt.Dockerfile
@@ -1,0 +1,13 @@
+FROM swift:5.3 as builder
+WORKDIR /swiftdoc
+COPY . .
+RUN apt-get -qq update && apt-get install -y libxml2-dev && rm -r /var/lib/apt/lists/*
+RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
+RUN make install prefix=/build
+
+FROM ubuntu:18.04
+RUN apt-get -qq update && apt-get install -y graphviz libatomic1 libxml2-dev libcurl4-openssl-dev && rm -r /var/lib/apt/lists/*
+COPY --from=builder /build/bin/swift-doc /usr/bin
+COPY --from=builder /build/lib/* /usr/lib/
+ENTRYPOINT ["swift-doc"]
+CMD ["--help"]


### PR DESCRIPTION
The only downside I currently see with this approach is that `Dockerfile` references the `latest` tag, while some actual release tag would be preferable. The latter means that on every release you would have to upload a new image and bump the release tag in `Dockerfile`.

Maybe using `latest` is fine for now, but should there be a corresponding CI action here that pushes new images on every commit to `master`?