### PR TITLE
Trigger publish from release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,83 +5,47 @@ on:
     types: [created, published]
 
 jobs:
-  macos:
-    name: Upload macOS Catalina release binary
-    runs-on: macos-10.15
-
-    strategy:
-      matrix:
-        xcode:
-          - "12" # Swift 5.3
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.release.tag_name }}
-      - name: Build and Package
-        run: |
-          make swift-doc
-          tar -cf swift-doc-${{ github.event.release.tag_name }}.catalina.bottle.tar swift-doc
-          gzip -f swift-doc-${{ github.event.release.tag_name }}.catalina.bottle.tar
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
-      - name: Upload
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./swift-doc
-          asset_name: swift-doc-${{ github.event.release.tag_name }}.catalina.bottle.tar.gz
-          asset_content_type: application/gzip
-
-  linux:
-    name: Upload Linux release binary
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        swift: ["5.3"]
-
-    container:
-      image: swift:${{ matrix.swift }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.release.tag_name }}
-      - name: Install System Dependencies
-        run: |
-          apt-get update
-          apt-get install -y libxml2-dev graphviz
-      - name: Build and Package
-        run: |
-          make swift-doc
-          tar -cf swift-doc-${{ github.event.release.tag_name }}.linux.bottle.tar.gz swift-doc
-          gzip -f swift-doc-${{ github.event.release.tag_name }}.linux.bottle.tar.gz
-      - name: Upload
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./swift-doc
-          asset_name: swift-doc-${{ github.event.release.tag_name }}.linux.bottle.tar.gz
-          asset_content_type: application/gzip
-
-  homebrew:
+  formula:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
-    needs: [macos, linux]
     steps:
-      - uses: NSHipster/update-homebrew-formula-action@main
+      - name: Update the Homebrew formula with latest release
+        uses: NSHipster/update-homebrew-formula-action@main
         with:
           repository: SwiftDocOrg/swift-doc
           tap: SwiftDocOrg/homebrew-formulae
           formula: Formula/swift-doc.rb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bottle:
+    name: Build and distribute Homebrew bottle for macOS Catalina
+    runs-on: macos-10.15
+    needs: [formula]
+    steps:
+      - name: Build a bottle using Homebrew
+        run: |
+          brew tap swiftdocorg/formulae
+          brew install --build-bottle --verbose swift-doc
+          brew bottle swift-doc
+      - name: Upload the bottle to the GitHub release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./swift-doc--${{ github.event.release.tag_name }}.catalina.bottle.tar.gz
+          asset_name: swift-doc-${{ github.event.release.tag_name }}.catalina.bottle.tar.gz
+          asset_content_type: application/gzip
+      - name: Update the Homebrew formula again with bottle
+        uses: NSHipster/update-homebrew-formula-action@main
+        with:
+          repository: SwiftDocOrg/swift-doc
+          tap: SwiftDocOrg/homebrew-formulae
+          formula: Formula/swift-doc.rb
+          message: |
+              Add bottle for swift-doc ${{ github.event.release.tag_name }}
+              on macOS Catalina
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
-name: Deploy
+name: Publish
 
 on:
   release:
-    types: [published]
+    types: [created, published]
 
 jobs:
   macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}


### PR DESCRIPTION
For the release of [1.0.0-beta.5](https://github.com/SwiftDocOrg/swift-doc/releases/tag/1.0.0-beta.5), I was excited to test out the automated release workflows put in place by #190. Unfortunately, things didn't work exactly as expected. Although a release was created in response to pushing a tag, the deploy workflow didn't trigger in response to that release being created. At first I thought it was an issue with the event type, but then I saw this [in the GitHub Actions documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token): 

> ## Triggering new workflows using a personal access token
>
> When you use the repository's `GITHUB_TOKEN` to perform tasks on behalf of the GitHub Actions app, events triggered by the `GITHUB_TOKEN` will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
>
> If you would like to trigger a workflow from a workflow run, you can trigger the event using a personal access token. You'll need to create a personal access token and store it as a secret. To minimize your GitHub Actions usage costs, ensure that you don't create recursive or unintended workflow runs.

This PR passes the `GH_PERSONAL_ACCESS_TOKEN` as `GITHUB_TOKEN` for the `actions/create-release` action, which should allow one workflow to trigger the other.