### PR TITLE
Specify names for macos and linux jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           - "11.7" # Swift 5.2
           - "12" # Swift 5.3
 
+    name: "macOS (Xcode ${{ matrix.xcode }})"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -40,6 +42,8 @@ jobs:
     strategy:
       matrix:
         swift: ["5.3", "5.2"]
+
+    name: "Linux (Swift ${{ matrix.swift }})"
 
     container:
       image: swift:${{ matrix.swift }}


### PR DESCRIPTION
Currently, CI workflow results look like this:

<img width="152" alt="Screen Shot 2020-10-06 at 10 51 44" src="https://user-images.githubusercontent.com/7659/95240983-042c6400-07c2-11eb-9c84-6824a1933a08.png">

These names are automatically generated based on the job key and the matrix value (Xcode 11.7 and 12 for `macos`; Swift 5.2 and 5.3 for `linux`). This PR uses interpolated matrix values to denote Xcode and Swift versions in the job names for clarity (if that indeed works).