### PR TITLE
Remove HTMLEntities dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -56,15 +56,6 @@
         }
       },
       {
-        "package": "HTMLEntities",
-        "repositoryURL": "https://github.com/IBM-Swift/swift-html-entities.git",
-        "state": {
-          "branch": null,
-          "revision": "744c094976355aa96ca61b9b60ef0a38e979feb7",
-          "version": "3.0.14"
-        }
-      },
-      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
@@ -113,8 +104,8 @@
         "package": "SwiftSyntaxHighlighter",
         "repositoryURL": "https://github.com/NSHipster/SwiftSyntaxHighlighter.git",
         "state": {
-          "branch": "1.1.0",
-          "revision": "b23b80be3032916dd5aefe9c621be25f75f3681f",
+          "branch": "1.1.1",
+          "revision": "76bd23ae4b23f028a8e45f906c2bf98312fb9d33",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.1.2")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
         .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.0.3")),
-        .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.1.0")),
+        .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.1.1")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.6")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.2.0")),
         .package(name: "LoggingGitHubActions", url: "https://github.com/NSHipster/swift-log-github-actions.git", .upToNextMinor(from: "0.0.1")),


### PR DESCRIPTION
As discussed in https://github.com/NSHipster/SwiftSyntaxHighlighter/pull/10, this PR updates SwiftSyntaxHighlighter to a version that doesn't have [Kitura/swift-html-entities](https://github.com/Kitura/swift-html-entities) as a dependency. This should have a marginal impact on binary size and compile time. 