### PR TITLE
Use PAT instead of GITHUB_TOKEN to access another repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           tap: SwiftDocOrg/homebrew-formulae
           formula: Formula/swift-doc.rb
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
   bottle:
     name: Build and distribute Homebrew bottle for macOS Catalina


### PR DESCRIPTION
We [carton team](https://github.com/swiftwasm/carton) uses a similar workflow of swift-doc and we found that `NSHipster/update-homebrew-formula-action` needs a GitHub token which has writing permission to tap repository.

[`secrets.GITHUB_TOKEN` doesn't have such permission](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token), so we need to use Personal Access Token instead. 