### PR TITLE
Don't link to not included symbols in the Relationships section.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed public extensions exposing nested code of all access levels.
   #195 by @Tunous.
+- Fixed broken links in the relationship graph.
+  #226 by @Lukas-Stuehrk.
 
 ### Changed
 

--- a/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
+++ b/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
@@ -36,13 +36,13 @@ extension Symbol {
         return node
     }
 
-    func graph(in module: Module, baseURL: String) -> Graph {
+    func graph(in module: Module, baseURL: String, symbolFilter: (Symbol) -> Bool) -> Graph {
         var graph = Graph(directed: true)
 
         do {
             var node = self.node
 
-            if !(api is Unknown) {
+            if !(api is Unknown) && symbolFilter(self) {
                 node.href = path(for: self, with: baseURL)
             }
 
@@ -61,7 +61,7 @@ extension Symbol {
             guard self != symbol else { continue }
             var node = symbol.node
 
-            if !(symbol.api is Unknown) {
+            if !(symbol.api is Unknown) && symbolFilter(symbol) {
                 node.href = path(for: symbol, with: baseURL)
             }
             graph.append(node)

--- a/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
+++ b/Sources/swift-doc/Extensions/SwiftDoc+Extensions.swift
@@ -36,7 +36,7 @@ extension Symbol {
         return node
     }
 
-    func graph(in module: Module, baseURL: String, symbolFilter: (Symbol) -> Bool) -> Graph {
+    func graph(in module: Module, baseURL: String, includingChildren symbolFilter: (Symbol) -> Bool) -> Graph {
         var graph = Graph(directed: true)
 
         do {

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -30,16 +30,18 @@ struct Relationships: Component {
     var symbol: Symbol
     let baseURL: String
     var inheritedTypes: [Symbol]
+    let symbolFilter: (Symbol) -> Bool
 
-    init(of symbol: Symbol, in module: Module, baseURL: String) {
+    init(of symbol: Symbol, in module: Module, baseURL: String, symbolFilter: @escaping (Symbol) -> Bool) {
         self.module = module
         self.symbol = symbol
         self.inheritedTypes = module.interface.typesInherited(by: symbol) + module.interface.typesConformed(by: symbol)
         self.baseURL = baseURL
+        self.symbolFilter = symbolFilter
     }
 
     var graphHTML: HypertextLiteral.HTML? {
-        var graph = symbol.graph(in: module, baseURL: baseURL)
+        var graph = symbol.graph(in: module, baseURL: baseURL, symbolFilter: symbolFilter)
         guard !graph.edges.isEmpty else { return nil }
 
         graph.aspectRatio = 0.125

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -41,7 +41,7 @@ struct Relationships: Component {
     }
 
     var graphHTML: HypertextLiteral.HTML? {
-        var graph = symbol.graph(in: module, baseURL: baseURL, includingChildren symbolFilter: symbolFilter)
+        var graph = symbol.graph(in: module, baseURL: baseURL, includingChildren: symbolFilter)
         guard !graph.edges.isEmpty else { return nil }
 
         graph.aspectRatio = 0.125

--- a/Sources/swift-doc/Supporting Types/Components/Relationships.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Relationships.swift
@@ -32,7 +32,7 @@ struct Relationships: Component {
     var inheritedTypes: [Symbol]
     let symbolFilter: (Symbol) -> Bool
 
-    init(of symbol: Symbol, in module: Module, baseURL: String, symbolFilter: @escaping (Symbol) -> Bool) {
+    init(of symbol: Symbol, in module: Module, baseURL: String, includingChildren symbolFilter: @escaping (Symbol) -> Bool) {
         self.module = module
         self.symbol = symbol
         self.inheritedTypes = module.interface.typesInherited(by: symbol) + module.interface.typesConformed(by: symbol)
@@ -41,7 +41,7 @@ struct Relationships: Component {
     }
 
     var graphHTML: HypertextLiteral.HTML? {
-        var graph = symbol.graph(in: module, baseURL: baseURL, symbolFilter: symbolFilter)
+        var graph = symbol.graph(in: module, baseURL: baseURL, includingChildren symbolFilter: symbolFilter)
         guard !graph.edges.isEmpty else { return nil }
 
         graph.aspectRatio = 0.125

--- a/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
@@ -28,7 +28,7 @@ struct TypePage: Page {
             Heading { symbol.id.description }
 
             Documentation(for: symbol, in: module, baseURL: baseURL)
-            Relationships(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter)
+            Relationships(of: symbol, in: module, baseURL: baseURL, includingChildren: symbolFilter)
             Members(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter)
             Requirements(of: symbol, in: module, baseURL: baseURL)
         }
@@ -42,7 +42,7 @@ struct TypePage: Page {
         </h1>
 
         \#(Documentation(for: symbol, in: module, baseURL: baseURL).html)
-        \#(Relationships(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter).html)
+        \#(Relationships(of: symbol, in: module, baseURL: baseURL, includingChildren: symbolFilter).html)
         \#(Members(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter).html)
         \#(Requirements(of: symbol, in: module, baseURL: baseURL).html)
         """#

--- a/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
@@ -28,7 +28,7 @@ struct TypePage: Page {
             Heading { symbol.id.description }
 
             Documentation(for: symbol, in: module, baseURL: baseURL)
-            Relationships(of: symbol, in: module, baseURL: baseURL)
+            Relationships(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter)
             Members(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter)
             Requirements(of: symbol, in: module, baseURL: baseURL)
         }
@@ -42,7 +42,7 @@ struct TypePage: Page {
         </h1>
 
         \#(Documentation(for: symbol, in: module, baseURL: baseURL).html)
-        \#(Relationships(of: symbol, in: module, baseURL: baseURL).html)
+        \#(Relationships(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter).html)
         \#(Members(of: symbol, in: module, baseURL: baseURL, symbolFilter: symbolFilter).html)
         \#(Requirements(of: symbol, in: module, baseURL: baseURL).html)
         """#


### PR DESCRIPTION
Not exactly the problem mentioned in #177, but a similar problem.

The problem described in #177 got a workaround in #204. Starting from there, symbols in the declaration don't have a link anymore.