### PR TITLE
Build documentation for extensions on external types.

### DIFF
--- a/Assets/css/all.css
+++ b/Assets/css/all.css
@@ -998,16 +998,6 @@ nav li[class] {
   padding-left: 2.5em;
 }
 
-#extensions {
-  & ul {
-    margin-left: 0;
-  }
-
-  & li {
-    list-style-type: none;
-  }
-}
-
 .associatedtype {
   --background-image: var(--icon-associatedtype);
   --link: var(--system-pink);

--- a/Assets/css/all.css
+++ b/Assets/css/all.css
@@ -998,6 +998,16 @@ nav li[class] {
   padding-left: 2.5em;
 }
 
+#extensions {
+  & ul {
+    margin-left: 0;
+  }
+
+  & li {
+    list-style-type: none;
+  }
+}
+
 .associatedtype {
   --background-image: var(--icon-associatedtype);
   --link: var(--system-pink);

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for generating documentation for
+  extensions to external types.
+  #230 by @Lukas-Stuehrk and @mattt.
 - Added end-to-end tests for command-line interface.
   #199 by @MaxDesiatov and @mattt.
 - Added `--minimum-access-level` option to `generate` and `coverage` commands.
@@ -59,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #159 by @mattt.
 - Fixed relationship diagram to prevent linking to unknown symbols.
   #178 by @MattKiazyk.
-- Fixed problems in CommonMark output related to escaping emoji shortcode. 
+- Fixed problems in CommonMark output related to escaping emoji shortcode.
   #167 by @mattt.
 
 ### Changed

--- a/Sources/SwiftDoc/Identifier.swift
+++ b/Sources/SwiftDoc/Identifier.swift
@@ -1,9 +1,24 @@
 public struct Identifier: Hashable {
-    public let pathComponents: [String]
+    public let context: [String]
     public let name: String
+    public let pathComponents: [String]
+
+    public init(context: [String], name: String) {
+        self.context = context
+        self.name = name
+        self.pathComponents = context + CollectionOfOne(name)
+    }
 
     public func matches(_ string: String) -> Bool {
-        (pathComponents + CollectionOfOne(name)).reversed().starts(with: string.split(separator: ".").map { String($0) }.reversed())
+        return matches(string.split(separator: "."))
+    }
+
+    public func matches(_ pathComponents: [Substring]) -> Bool {
+        return matches(pathComponents.map(String.init))
+    }
+
+    public func matches(_ pathComponents: [String]) -> Bool {
+        return self.pathComponents.ends(with: pathComponents)
     }
 }
 
@@ -11,6 +26,16 @@ public struct Identifier: Hashable {
 
 extension Identifier: CustomStringConvertible {
     public var description: String {
-        (pathComponents + CollectionOfOne(name)).joined(separator: ".")
+        pathComponents.joined(separator: ".")
+    }
+}
+
+fileprivate extension Array {
+    func ends<PossibleSuffix>(with possibleSuffix: PossibleSuffix) -> Bool
+        where PossibleSuffix : Sequence,
+              Self.Element == PossibleSuffix.Element,
+              Self.Element: Equatable
+    {
+        reversed().starts(with: possibleSuffix)
     }
 }

--- a/Sources/SwiftDoc/Interface.swift
+++ b/Sources/SwiftDoc/Interface.swift
@@ -164,7 +164,7 @@ public final class Interface {
 
     public func symbols(named name: String, resolvingTypealiases: Bool) -> [Symbol] {
         var pathComponents: [String] = []
-        for component in name.split(separator: ".", omittingEmptySubsequences: true) {
+        for component in name.split(separator: ".") {
             pathComponents.append("\(component)")
             guard resolvingTypealiases else { continue }
 

--- a/Sources/SwiftDoc/Interface.swift
+++ b/Sources/SwiftDoc/Interface.swift
@@ -159,4 +159,38 @@ public final class Interface {
     public func defaultImplementations(of symbol: Symbol) -> [Symbol] {
         return relationshipsByObject[symbol.id]?.filter { $0.predicate == .defaultImplementationOf }.map { $0.subject }.sorted() ?? []
     }
+
+    // MARK: -
+
+    /// Whether the symbol with the given qualified name is declared inside this module or not.
+    ///
+    /// Please note that this tool only operates on the syntax tree and does not have a semantic understanding of the
+    /// symbols, so this method might produce false positives.
+    ///
+    ///  - Parameter name: A qualified name of a symbol.
+    ///  - Returns: Whether or not the symbol is external, meaning that it is not declared in the module.
+    public func isExternalSymbol(named name: String) -> Bool {
+        var nameComponents: [String] = name.split(separator: ".").map(String.init).reversed()
+        var path: [String] = []
+        while let nextComponent = nameComponents.popLast() {
+            guard let symbol = findSymbol(named: nextComponent, path: path) else { return true }
+            path.append(symbol.name)
+        }
+        return false
+    }
+
+    private func findSymbol(named name: String, path immutablePath: [String]) -> Symbol? {
+        var path = immutablePath
+        repeat {
+            let fullPath = (path + CollectionOfOne(name)).joined(separator: ".")
+            if let symbol = symbolsGroupedByQualifiedName[fullPath]?.first {
+                guard let typealiasDeclaration = symbol.api as? Typealias, let initializedName = typealiasDeclaration.initializedType else { return symbol }
+                guard !symbol.context.isEmpty else {
+                   return findSymbol(named: initializedName, path: [])
+                }
+                return findSymbol(named: initializedName, path: symbol.context.compactMap { ($0 as? Symbol)?.name ?? ($0 as? Extension)?.extendedType })
+            }
+        } while path.popLast() != nil
+        return nil
+    }
 }

--- a/Sources/SwiftDoc/Symbol.swift
+++ b/Sources/SwiftDoc/Symbol.swift
@@ -6,6 +6,7 @@ import struct Highlighter.Token
 public final class Symbol {
     public typealias ID = Identifier
 
+    public let id: ID
     public let api: API
     public let context: [Contextual]
     public let declaration: [Token]
@@ -19,6 +20,9 @@ public final class Symbol {
     public private(set) lazy var conditions: [CompilationCondition] = context.compactMap { $0 as? CompilationCondition }
 
     init(api: API, context: [Contextual], declaration: [Token], documentation: Documentation?, sourceRange: SourceRange?) {
+        self.id = Identifier(context: context.compactMap {
+            ($0 as? Symbol)?.name ?? ($0 as? Extension)?.extendedType
+        }, name: api.name)
         self.api = api
         self.context = context
         self.declaration = declaration
@@ -29,12 +33,6 @@ public final class Symbol {
     public var name: String {
         return api.name
     }
-
-    public private(set) lazy var id: ID = {
-        Identifier(pathComponents: context.compactMap {
-            ($0 as? Symbol)?.name ?? ($0 as? Extension)?.extendedType
-        }, name: name)
-    }()
 
     public var isPublic: Bool {
         if api is Unknown {

--- a/Sources/SwiftDoc/Symbol.swift
+++ b/Sources/SwiftDoc/Symbol.swift
@@ -329,3 +329,9 @@ extension Symbol: Codable {
         try container.encode(sourceRange, forKey: .sourceRange)
     }
 }
+
+extension Symbol: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "\(self.declaration.map { $0.text }.joined())"
+    }
+}

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -65,10 +65,10 @@ extension SwiftDoc {
           switch symbol.api {
           case is Class, is Enumeration, is Structure, is Protocol:
             pages[route(for: symbol)] = TypePage(module: module, symbol: symbol, baseURL: baseURL, includingChildren: symbolFilter)
-            declaredTypeNames.append(symbol.name)
+            declaredTypeNames.append(symbol.id.description)
           case let `typealias` as Typealias:
             pages[route(for: `typealias`.name)] = TypealiasPage(module: module, symbol: symbol, baseURL: baseURL)
-            declaredTypeNames.append(symbol.name)
+            declaredTypeNames.append(symbol.id.description)
           case let function as Function where !function.isOperator:
             globals[function.name, default: []] += [symbol]
           case let variable as Variable:

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -79,7 +79,7 @@ extension SwiftDoc {
         var symbolsByExternalType: [String: [Symbol]] = [:]
         for symbol in module.interface.symbols.filter(symbolFilter) {
           guard let extensionDeclaration = symbol.context.first as? Extension, symbol.context.count == 1 else { continue }
-          guard module.interface.isExternalSymbol(named: extensionDeclaration.extendedType) else { continue }
+          guard module.interface.symbols(named: extensionDeclaration.extendedType, resolvingTypealiases: true).isEmpty else { continue }
           symbolsByExternalType[extensionDeclaration.extendedType, default: []] += [symbol]
         }
         for (typeName, symbols) in symbolsByExternalType {

--- a/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
@@ -1,0 +1,87 @@
+import CommonMarkBuilder
+import SwiftDoc
+import HypertextLiteral
+import SwiftMarkup
+import SwiftSemantics
+
+struct ExternalTypePage: Page {
+
+    let module: Module
+    let externalType: String
+    let baseURL: String
+
+    let typealiases: [Symbol]
+    let initializers: [Symbol]
+    let properties: [Symbol]
+    let methods: [Symbol]
+
+    init(module: Module, externalType: String, symbols: [Symbol], baseURL: String) {
+        self.module = module
+        self.externalType = externalType
+        self.baseURL = baseURL
+
+        self.typealiases = symbols.filter { $0.api is Typealias }
+        self.initializers = symbols.filter { $0.api is Initializer }
+        self.properties = symbols.filter { $0.api is Variable }
+        self.methods = symbols.filter { $0.api is Function }
+    }
+
+    var title: String { externalType }
+
+    var sections: [(title: String, members: [Symbol])] {
+        return [
+            ("Nested Type Aliases", typealiases),
+            ("Initializers", initializers),
+            ("Properties", properties),
+            ("Methods", methods),
+        ].filter { !$0.members.isEmpty }
+    }
+
+    var document: CommonMark.Document {
+        Document {
+            Heading { "Extensions on \(externalType)" }
+            ForEach(in: sections) { section -> BlockConvertible in
+                Section {
+                    Heading { section.title }
+
+                    Section {
+                        ForEach(in: section.members) { member in
+                            Heading {
+                                Code { member.name }
+                            }
+                            Documentation(for: member, in: module, baseURL: baseURL)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    var html: HypertextLiteral.HTML {
+        #"""
+        <h1>
+            <small>Extensions on</small>
+            <code class="name">\#(externalType)</code>
+        </h1>
+        \#(sections.map { section -> HypertextLiteral.HTML in
+            #"""
+                <section id=\#(section.title.lowercased())>
+                    <h2>\#(section.title)</h2>
+
+                    \#(section.members.map { member -> HypertextLiteral.HTML in
+                    let descriptor = String(describing: type(of: member.api)).lowercased()
+
+                    return #"""
+                           <div role="article" class="\#(descriptor)" id=\#(member.id.description.lowercased().replacingOccurrences(of: " ", with: "-"))>
+                               <h3>
+                                   <code>\#(softbreak(member.name))</code>
+                               </h3>
+                               \#(Documentation(for: member, in: module, baseURL: baseURL).html)
+                           </div>
+                           """#
+                })
+                </section>
+            """#
+        })
+        """#
+    }
+}

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -16,9 +16,13 @@ struct HomePage: Page {
     var globalFunctions: [Symbol] = []
     var globalVariables: [Symbol] = []
 
-    init(module: Module, baseURL: String, symbolFilter: (Symbol) -> Bool) {
+    let externalTypes: [String]
+
+    init(module: Module, externalTypes: [String], baseURL: String, symbolFilter: (Symbol) -> Bool) {
         self.module = module
         self.baseURL = baseURL
+
+        self.externalTypes = externalTypes
 
         for symbol in module.interface.topLevelSymbols.filter(symbolFilter) {
             switch symbol.api {
@@ -70,6 +74,18 @@ struct HomePage: Page {
                     }
                 }
             }
+
+            if !externalTypes.isEmpty {
+                Heading { "Extensions"}
+
+                List(of: externalTypes.sorted()) { typeName in
+                    List.Item {
+                        Paragraph {
+                            Link(urlString: path(for: route(for: typeName), with: baseURL), text: typeName)
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -95,6 +111,20 @@ struct HomePage: Page {
             </section>
         """#
         })
+        \#((externalTypes.isEmpty ? "" :
+            #"""
+            <section id="extensions">
+                <h2>Extensions</h2>
+                <ul>
+                \#(externalTypes.sorted().map {
+                    #"""
+                    <li><a href="\#(path(for: route(for: $0), with: baseURL))">\#($0)</a></li>
+                    """# as HypertextLiteral.HTML
+                })
+                </ul>
+            <section>
+            """#
+        ) as HypertextLiteral.HTML)
         """#
     }
 }

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -115,13 +115,16 @@ struct HomePage: Page {
             #"""
             <section id="extensions">
                 <h2>Extensions</h2>
-                <ul>
+                <dl>
                 \#(externalTypes.sorted().map {
                     #"""
-                    <li><a href="\#(path(for: route(for: $0), with: baseURL))">\#($0)</a></li>
+                    <dt class="extension">
+                        <a href="\#(path(for: route(for: $0), with: baseURL))">\#($0)</a>
+                    </dt>
+                    <dd></dd>
                     """# as HypertextLiteral.HTML
                 })
-                </ul>
+                </dl>
             <section>
             """#
         ) as HypertextLiteral.HTML)

--- a/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
@@ -14,9 +14,13 @@ struct SidebarPage: Page {
     var globalFunctionNames: Set<String> = []
     var globalVariableNames: Set<String> = []
 
-    init(module: Module, baseURL: String, symbolFilter: (Symbol) -> Bool) {
+    let externalTypes: Set<String>
+
+    init(module: Module, externalTypes: Set<String>, baseURL: String, symbolFilter: (Symbol) -> Bool) {
         self.module = module
         self.baseURL = baseURL
+
+        self.externalTypes = externalTypes
 
         for symbol in module.interface.topLevelSymbols.filter(symbolFilter) {
             switch symbol.api {
@@ -55,7 +59,8 @@ struct SidebarPage: Page {
                     ("Global Typealiases", globalTypealiasNames),
                     ("Global Variables",globalVariableNames),
                     ("Global Functions", globalFunctionNames),
-                    ("Operators", operatorNames)
+                    ("Operators", operatorNames),
+                    ("Extensions", externalTypes),
                 ] as [(title: String, names: Set<String>)]
             ).filter { !$0.names.isEmpty }) { section in
                 // FIXME: This should be an HTML block

--- a/Tests/SwiftDocTests/InterfaceTypeTests.swift
+++ b/Tests/SwiftDocTests/InterfaceTypeTests.swift
@@ -291,15 +291,34 @@ final class InterfaceTypeTests: XCTestCase {
         let sourceFile = try SourceFile(file: url, relativeTo: url.deletingLastPathComponent())
         let module = Module(name: "Module", sourceFiles: [sourceFile])
 
-        XCTAssertFalse(module.interface.isExternalSymbol(named: "SomeClass"))
-        XCTAssertFalse(module.interface.isExternalSymbol(named: "SomeClass.InnerObject"))
-        XCTAssertFalse(module.interface.isExternalSymbol(named: "MyClass"))
-        XCTAssertFalse(module.interface.isExternalSymbol(named: "MyClass.InnerObject"))
-        XCTAssertTrue(module.interface.isExternalSymbol(named: "UIGestureRecognizer"))
-        XCTAssertTrue(module.interface.isExternalSymbol(named: "UIGestureRecognizer.State"))
-        XCTAssertTrue(module.interface.isExternalSymbol(named: "ExternalClass"))
-        XCTAssertTrue(module.interface.isExternalSymbol(named: "ExternalClass.State"))
-        XCTAssertTrue(module.interface.isExternalSymbol(named: "SomeClass.ActuallyExternal"))
-        XCTAssertFalse(module.interface.isExternalSymbol(named: "SomeClass.ActuallyInternal"))
+        XCTAssertEqual(module.interface.symbols(named: "SomeClass", resolvingTypealiases: true).first?.name, "SomeClass")
+        XCTAssertEqual(module.interface.symbols(named: "SomeClass", resolvingTypealiases: false).first?.name, "SomeClass")
+
+        XCTAssertEqual(module.interface.symbols(named: "SomeClass.InnerObject", resolvingTypealiases: true).first?.name, "InnerObject")
+        XCTAssertEqual(module.interface.symbols(named: "SomeClass.InnerObject", resolvingTypealiases: false).first?.name, "InnerObject")
+
+        XCTAssertEqual(module.interface.symbols(named: "SomeClass.ActuallyInternal", resolvingTypealiases: true).first?.name, "InnerStruct")
+        XCTAssertEqual(module.interface.symbols(named: "SomeClass.ActuallyInternal", resolvingTypealiases: false).first?.name, "ActuallyInternal")
+
+        XCTAssertEqual(module.interface.symbols(named: "MyClass", resolvingTypealiases: true).first?.name, "SomeClass")
+        XCTAssertEqual(module.interface.symbols(named: "MyClass", resolvingTypealiases: false).first?.name, "MyClass")
+
+        XCTAssertEqual(module.interface.symbols(named: "MyClass.InnerObject", resolvingTypealiases: true).first?.name, "InnerObject")
+        XCTAssertNil(module.interface.symbols(named: "MyClass.InnerObject", resolvingTypealiases: false).first)
+
+        XCTAssertNil(module.interface.symbols(named: "ExternalClass", resolvingTypealiases: true).first)
+        XCTAssertTrue(module.interface.symbols(named: "ExternalClass", resolvingTypealiases: false).first?.api is Typealias)
+
+        XCTAssertNil(module.interface.symbols(named: "ExternalClass.State", resolvingTypealiases: true).first)
+        XCTAssertNil(module.interface.symbols(named: "ExternalClass.State", resolvingTypealiases: false).first)
+
+        XCTAssertNil(module.interface.symbols(named: "SomeClass.ActuallyExternal", resolvingTypealiases: true).first)
+        XCTAssertTrue(module.interface.symbols(named: "SomeClass.ActuallyExternal", resolvingTypealiases: false).first?.api is Typealias)
+
+        XCTAssertNil(module.interface.symbols(named: "UIGestureRecognizer", resolvingTypealiases: true).first)
+        XCTAssertNil(module.interface.symbols(named: "UIGestureRecognizer", resolvingTypealiases: false).first)
+
+        XCTAssertNil(module.interface.symbols(named: "UIGestureRecognizer.State", resolvingTypealiases: true).first)
+        XCTAssertNil(module.interface.symbols(named: "UIGestureRecognizer.State", resolvingTypealiases: false).first)
     }
 }

--- a/Tests/SwiftDocTests/InterfaceTypeTests.swift
+++ b/Tests/SwiftDocTests/InterfaceTypeTests.swift
@@ -282,6 +282,10 @@ final class InterfaceTypeTests: XCTestCase {
          }
                       
          public typealias MyClass = SomeClass
+
+         public class AnotherClass {
+             typealias PublicClass = SomeClass
+         }
                      
          public typealias ExternalClass = UIGestureRecognizer
          """#
@@ -305,6 +309,12 @@ final class InterfaceTypeTests: XCTestCase {
 
         XCTAssertEqual(module.interface.symbols(named: "MyClass.InnerObject", resolvingTypealiases: true).first?.name, "InnerObject")
         XCTAssertNil(module.interface.symbols(named: "MyClass.InnerObject", resolvingTypealiases: false).first)
+
+        XCTAssertEqual(module.interface.symbols(named: "AnotherClass.PublicClass", resolvingTypealiases: true).first?.name, "SomeClass")
+        XCTAssertTrue(module.interface.symbols(named: "AnotherClass.PublicClass", resolvingTypealiases: false).first?.api is Typealias)
+
+        XCTAssertEqual(module.interface.symbols(named: "AnotherClass.PublicClass.ActuallyInternal", resolvingTypealiases: true).first?.name, "InnerStruct")
+        XCTAssertNil(module.interface.symbols(named: "AnotherClass.PublicClass.ActuallyInternal", resolvingTypealiases: false).first)
 
         XCTAssertNil(module.interface.symbols(named: "ExternalClass", resolvingTypealiases: true).first)
         XCTAssertTrue(module.interface.symbols(named: "ExternalClass", resolvingTypealiases: false).first?.api is Typealias)

--- a/Tests/SwiftDocTests/InterfaceTypeTests.swift
+++ b/Tests/SwiftDocTests/InterfaceTypeTests.swift
@@ -331,4 +331,32 @@ final class InterfaceTypeTests: XCTestCase {
         XCTAssertNil(module.interface.symbols(named: "UIGestureRecognizer.State", resolvingTypealiases: true).first)
         XCTAssertNil(module.interface.symbols(named: "UIGestureRecognizer.State", resolvingTypealiases: false).first)
     }
+
+    public func testMembersOfTypealiasedSymbols() throws {
+        let source = #"""
+        public class SomeClass {
+            public func someMethod() { }
+        }
+                
+        public typealias OtherClass = SomeClass
+                
+        public extension OtherClass {
+            func someExtensionMethod() { }
+        }
+        """#
+
+
+        let url = try temporaryFile(contents: source)
+        let sourceFile = try SourceFile(file: url, relativeTo: url.deletingLastPathComponent())
+        let module = Module(name: "Module", sourceFiles: [sourceFile])
+
+        XCTAssertEqual(module.interface.symbols.count, 4)
+
+        let someClass = module.interface.symbols[0]
+        XCTAssertEqual(someClass.name, "SomeClass")
+        let members = module.interface.members(of: someClass)
+        XCTAssertEqual(2, members.count)
+        XCTAssertEqual(members[0].name, "someMethod()")
+        XCTAssertEqual(members[1].name, "someExtensionMethod()")
+    }
 }


### PR DESCRIPTION
With this change, swift-doc also generates documentation for symbols declared in extensions on external types. This implements #122.

On the homepage, every external type is listed (in a visually very uninspired way) in a new section "Extensions". The following screenshots shows extensions on two different classes of UIKit. One time the external type is referenced with its full name, including the module. One time the external type is referenced only with its class name.
<img width="1142" alt="Screenshot 2021-03-27 at 23 21 58" src="https://user-images.githubusercontent.com/245433/112736874-4dca6000-8f56-11eb-97af-c591d43cf051.png">

For every external type, a new page is generated and lists the symbols, similar to the already existing pages for types.
<img width="1108" alt="Screenshot 2021-03-27 at 23 21 08" src="https://user-images.githubusercontent.com/245433/112736740-52dadf80-8f55-11eb-964e-1db61ac1794d.png">


Not changed is the behavior for structs and classes which are declared in extensions on external types. Swift-doc already creates documentation for these types.
