### PR TITLE
Add a workflow to validate the generated assets on CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('.node/**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Install node dependencies
         run: |
           cd .node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,30 @@ jobs:
           apt-get install -y libxml2-dev graphviz
       - name: Build and Test
         run: swift test -c release --enable-test-discovery
+
+  validate-assets:
+    runs-on: ubuntu-latest
+
+    name: "Validate Assets"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Install node dependencies
+        run: |
+          cd .node
+          npm install
+      - name: Test assets
+        run: |
+          cd .node
+          OLD=`cksum ../Resources/all.min.css`
+          npm run build
+          NEW=`cksum ../Resources/all.min.css`
+          if [[ "$OLD" != "$NEW" ]]; then
+            echo "Regenerated assets differ from committed version"
+            exit -1
+          fi

--- a/.node/package.json
+++ b/.node/package.json
@@ -5,7 +5,8 @@
     "not dead"
   ],
   "scripts": {
-    "watch": "postcss -w ../Assets/**/*.css -o ../Resources/all.min.css --config ./postcss.config.js"
+    "watch": "postcss -w ../Assets/**/*.css -o ../Resources/all.min.css --config ./postcss.config.js",
+    "build": "postcss ../Assets/**/*.css -o ../Resources/all.min.css --config ./postcss.config.js"
   },
   "dependencies": {
     "cssnano": "^4.1.10",


### PR DESCRIPTION
It's rather easy to accidentally commit the wrong version of the generated CSS assets. Or to not commit the generated version and only the changed source. And it's not easy to validate if the generated CSS of a pull request correlates to the sources of the pull request.

This change introduces a new pipeline for CI. This pipeline builds the CSS from the sources and validates that the committed version of the generated CSS is identical to building it from source.