### PR TITLE
Display a warning if an input directory does not exist.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed serialization of `Symbol` to encode and decode `sourceRange` key
   instead of `sourceLocation` key.
   #237 by @mattt.
+- Changed commands to warn when invalid paths are passed.
+  #242 by @Lukas-Stuehrk.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ apt-get install -y libxml2-dev graphviz
     USAGE: swift doc generate [<inputs> ...] --module-name <module-name> [--output <output>] [--format <format>] [--base-url <base-url>]
 
     ARGUMENTS:
-      <inputs>                One or more paths to Swift files 
+      <inputs>                One or more paths to a directory containing Swift files. 
 
     OPTIONS:
       -n, --module-name <module-name>
@@ -150,7 +150,7 @@ pass the `--minimum-access-level` flag with the specified access level.
     USAGE: swift doc coverage [<inputs> ...] [--output <output>]
 
     ARGUMENTS:
-      <inputs>                One or more paths to Swift files 
+      <inputs>                One or more paths to a directory containing Swift files.
 
     OPTIONS:
       -o, --output <output>   The path for generated report 
@@ -202,7 +202,7 @@ please reach out by [opening an Issue][open an issue]!
     USAGE: swift doc diagram [<inputs> ...]
 
     ARGUMENTS:
-      <inputs>                One or more paths to Swift files 
+      <inputs>                One or more paths to a directory containing Swift files.
 
     OPTIONS:
       --minimum-access-level <minimum-access-level>

--- a/Sources/swift-doc/Subcommands/Coverage.swift
+++ b/Sources/swift-doc/Subcommands/Coverage.swift
@@ -6,7 +6,7 @@ import SwiftDoc
 extension SwiftDoc {
     struct Coverage: ParsableCommand {
         struct Options: ParsableArguments {
-            @Argument(help: "One or more paths to Swift files")
+            @Argument(help: "One or more paths to a directory containing Swift files.")
             var inputs: [String]
 
             @Option(name: .shortAndLong,

--- a/Sources/swift-doc/Subcommands/Diagram.swift
+++ b/Sources/swift-doc/Subcommands/Diagram.swift
@@ -7,7 +7,7 @@ import GraphViz
 extension SwiftDoc {
     struct Diagram: ParsableCommand {
         struct Options: ParsableArguments {
-            @Argument(help: "One or more paths to Swift files")
+            @Argument(help: "One or more paths to a directory containing Swift files.")
             var inputs: [String]
 
             @Option(name: .long,

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -47,6 +47,15 @@ extension SwiftDoc {
     var options: Options
 
     func run() throws {
+      for directory in options.inputs {
+        var isDirectory: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: directory, isDirectory: &isDirectory) {
+          logger.warning("Input directory \(directory) does not exist.")
+        } else if !isDirectory.boolValue {
+          logger.warning("Input path \(directory) is not a directory.")
+        }
+      }
+
       let module = try Module(name: options.moduleName, paths: options.inputs)
       let baseURL = options.baseURL
 

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -17,7 +17,7 @@ extension SwiftDoc {
     }
 
     struct Options: ParsableArguments {
-      @Argument(help: "One or more paths to Swift files")
+      @Argument(help: "One or more paths to a directory containing Swift files.")
       var inputs: [String]
 
       @Option(name: [.long, .customShort("n")],

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -50,7 +50,7 @@ extension SwiftDoc {
       for directory in options.inputs {
         var isDirectory: ObjCBool = false
         if !FileManager.default.fileExists(atPath: directory, isDirectory: &isDirectory) {
-          logger.warning("Input directory \(directory) does not exist.")
+          logger.warning("Input path \(directory) does not exist.")
         } else if !isDirectory.boolValue {
           logger.warning("Input path \(directory) is not a directory.")
         }


### PR DESCRIPTION
A small improvement, so users can troubleshoot problems easier. 

Before, when you accidentally misspelled the input path or provided for any other reason a path to directory which does not exist, swift-doc only displayed a warning that no symbols where found. This could lead new users into a very wrong direction.

With this change, there's an additional warning that the given directory does not exist. If an input path exists but is not a directory, a helpful warning is displayed as well, as swift-doc only works with paths to directories and not direct paths to Swift source files.