### PR TITLE
Add end-to-end continuous integration tests for Homebrew distribution

### DIFF
--- a/.github/workflows/homebrew_ci.yml
+++ b/.github/workflows/homebrew_ci.yml
@@ -1,4 +1,4 @@
-name: homebrew CI
+name: Homebrew CI
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
   homebrew-bottle:
     runs-on: macos-10.15
-    name: homebrew from bottle
+    name: Test Homebrew installation from bottle
 
     steps:
       - name: Checkout
@@ -29,7 +29,7 @@ jobs:
   homebrew-sources:
     runs-on: macos-11.0
 
-    name: homebrew from source
+    name: Test Homebrew installation from sources
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/homebrew_ci.yml
+++ b/.github/workflows/homebrew_ci.yml
@@ -1,0 +1,45 @@
+name: homebrew CI
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  homebrew-bottle:
+    runs-on: macos-10.15
+    name: homebrew from bottle
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-
+      - name: Install swift-doc
+        run: brew install swiftdocorg/formulae/swift-doc --force-bottle
+      - name: Run Tests
+        run: |
+          swift test --filter EndToEndTests. -Xswiftc -DUSE_HOMEBREW
+
+  homebrew-sources:
+    runs-on: macos-11.0
+
+    name: homebrew from source
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-xcode-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-xcode-
+      - name: Install swift-doc
+        run: brew install swiftdocorg/formulae/swift-doc --build-from-source
+      - name: Run Tests
+        run: swift test --filter EndToEndTests. -Xswiftc -DUSE_HOMEBREW

--- a/Tests/EndToEndTests/CoverageSubcommandTests.swift
+++ b/Tests/EndToEndTests/CoverageSubcommandTests.swift
@@ -2,12 +2,10 @@ import XCTest
 
 final class CoverageSubcommandTests: XCTestCase {
     func testStandardOutput() throws {
-        let command = getSwiftDocCommand()
-
         let outputDirectory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try Process.run(command: command,
+        try Process.run(command: swiftDocCommand,
                         arguments: [
                             "coverage",
                             "Sources"
@@ -20,13 +18,11 @@ final class CoverageSubcommandTests: XCTestCase {
     }
 
     func testFileOutput() throws {
-        let command = getSwiftDocCommand()
-        
         let outputDirectory = try temporaryDirectory()
         let outputFile = outputDirectory.appendingPathComponent("report.json")
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try Process.run(command: command,
+        try Process.run(command: swiftDocCommand,
                         arguments: [
                             "coverage",
                             "--output", outputFile.path,

--- a/Tests/EndToEndTests/CoverageSubcommandTests.swift
+++ b/Tests/EndToEndTests/CoverageSubcommandTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 final class CoverageSubcommandTests: XCTestCase {
     func testStandardOutput() throws {
-        let command = Bundle.productsDirectory.appendingPathComponent("swift-doc")
+        let command = getSwiftDocCommand()
 
         let outputDirectory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
@@ -20,7 +20,7 @@ final class CoverageSubcommandTests: XCTestCase {
     }
 
     func testFileOutput() throws {
-        let command = Bundle.productsDirectory.appendingPathComponent("swift-doc")
+        let command = getSwiftDocCommand()
         
         let outputDirectory = try temporaryDirectory()
         let outputFile = outputDirectory.appendingPathComponent("report.json")

--- a/Tests/EndToEndTests/DiagramSubcommandTests.swift
+++ b/Tests/EndToEndTests/DiagramSubcommandTests.swift
@@ -2,12 +2,10 @@ import XCTest
 
 final class DiagramSubcommandTests: XCTestCase {
     func testStandardOutput() throws {
-        let command = getSwiftDocCommand()
-
         let outputDirectory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try Process.run(command: command,
+        try Process.run(command: swiftDocCommand,
                         arguments: [
                             "diagram",
                             "Sources"

--- a/Tests/EndToEndTests/DiagramSubcommandTests.swift
+++ b/Tests/EndToEndTests/DiagramSubcommandTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 final class DiagramSubcommandTests: XCTestCase {
     func testStandardOutput() throws {
-        let command = Bundle.productsDirectory.appendingPathComponent("swift-doc")
+        let command = getSwiftDocCommand()
 
         let outputDirectory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }

--- a/Tests/EndToEndTests/GenerateSubcommandTests.swift
+++ b/Tests/EndToEndTests/GenerateSubcommandTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 final class GenerateSubcommandTests: XCTestCase {
     func testCommonMark() throws {
-        let command = Bundle.productsDirectory.appendingPathComponent("swift-doc")
+        let command = getSwiftDocCommand()
 
         let outputDirectory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }

--- a/Tests/EndToEndTests/GenerateSubcommandTests.swift
+++ b/Tests/EndToEndTests/GenerateSubcommandTests.swift
@@ -2,12 +2,10 @@ import XCTest
 
 final class GenerateSubcommandTests: XCTestCase {
     func testCommonMark() throws {
-        let command = getSwiftDocCommand()
-
         let outputDirectory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try Process.run(command: command,
+        try Process.run(command: swiftDocCommand,
                         arguments: [
                             "generate",
                             "--module-name", "SwiftDoc",
@@ -44,11 +42,10 @@ final class GenerateSubcommandTests: XCTestCase {
     }
 
     func testHTML() throws {
-        let command = Bundle.productsDirectory.appendingPathComponent("swift-doc")
         let outputDirectory = try temporaryDirectory()
 
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
-        try Process.run(command: command,
+        try Process.run(command: swiftDocCommand,
                         arguments: [
                             "generate",
                             "--module-name", "SwiftDoc",

--- a/Tests/EndToEndTests/Helpers/XCTestCase+Extensions.swift
+++ b/Tests/EndToEndTests/Helpers/XCTestCase+Extensions.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+extension XCTestCase {
+    func getSwiftDocCommand() -> URL {
+        #if USE_HOMEBREW
+        return URL(fileURLWithPath: "/usr/local/bin/swift-doc")
+        #else
+        return Bundle.productsDirectory.appendingPathComponent("swift-doc")
+        #endif
+    }
+}

--- a/Tests/EndToEndTests/Helpers/XCTestCase+Extensions.swift
+++ b/Tests/EndToEndTests/Helpers/XCTestCase+Extensions.swift
@@ -1,7 +1,8 @@
 import XCTest
+import Foundation
 
 extension XCTestCase {
-    func getSwiftDocCommand() -> URL {
+    var swiftDocCommand: URL {
         #if USE_HOMEBREW
         return URL(fileURLWithPath: "/usr/local/bin/swift-doc")
         #else


### PR DESCRIPTION
This changes the end-to-end tests so it's possible to use the tests with the `swift-doc` version installed via homebrew.

It also adds a new GitHub actions workflow to run the end-to-tests with the homebrew version of swift-doc, both from bottle and from source.

This implements #202.

Unfortunately, the integration tests will fail. I can reproduce this also on my machine when I use the swift-doc version from homebrew:

```bash
lukas@grumpycat ~/src/swift-doc $ which swift-doc                                                                           
/Users/lukas/homebrew/bin/swift-doc
lukas@grumpycat ~/src/swift-doc $ swift-doc generate --module-name SwiftDoc --format commonmark --output /tmp/docs .
[1]    47753 illegal hardware instruction  swift-doc generate --module-name SwiftDoc --format commonmark --output  .
```

The crashing line is https://github.com/SwiftDocOrg/swift-doc/blob/f441648bcb8a6b07a3724bc1af2488e8a6e6c184/Sources/SwiftDoc/SourceFile.swift#L141-L141