### PR TITLE
Add minimum-access-level input to action.yml again.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "The path for generated output"
     required: true
     default: "./.build/documentation"
+  minimum-access-level:
+    description: "The minimum access level of the symbols which should be included (public, internal, or private)"
+    required: false
+    default: "public"
 
 runs:
   using: "docker"
@@ -37,6 +41,8 @@ runs:
       "${{ inputs.module-name }}",
       --output,
       "${{ inputs.output }}",
+      --minimum-access-level,
+      "${{ inputs.minimum-access-level }}"
     ]
 
 branding:


### PR DESCRIPTION
Now with the release of `1.0.0-beta.6` we can finally make this available in the GitHub action.