### PR TITLE
swift-doc: load FoundationNetworking on non-Darwin platforms

### DIFF
--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -5,7 +5,7 @@ import SwiftMarkup
 import SwiftSemantics
 import struct SwiftSemantics.Protocol
 
-#if os(Linux)
+#if !(os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
 import FoundationNetworking
 #endif
 

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -5,7 +5,7 @@ import SwiftMarkup
 import SwiftSemantics
 import struct SwiftSemantics.Protocol
 
-#if !(os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 


### PR DESCRIPTION
Invert the condition to not link against Foundation networking only on
non-Darwin platforms.  Every other platform uses
swift-corelibs-foundation which provides a FoundationNetworking which
must be linked against in order to have the networking functionality
work.  This repairs the fetch of the CSS for Windows hosts.