### PR TITLE
Fix toplevel symbols

### DIFF
--- a/Sources/SwiftDoc/Interface.swift
+++ b/Sources/SwiftDoc/Interface.swift
@@ -24,7 +24,7 @@ public final class Interface {
                 return false
             }
 
-            return symbol.id.pathComponents.isEmpty
+            return symbol.id.pathComponents.count == 1
         }
 
         self.relationships = {

--- a/Sources/SwiftDoc/Interface.swift
+++ b/Sources/SwiftDoc/Interface.swift
@@ -24,7 +24,7 @@ public final class Interface {
                 return false
             }
 
-            return symbol.id.pathComponents.count == 1
+            return symbol.id.context.isEmpty
         }
 
         self.relationships = {

--- a/Tests/SwiftDocTests/InterfaceTypeTests.swift
+++ b/Tests/SwiftDocTests/InterfaceTypeTests.swift
@@ -359,4 +359,34 @@ final class InterfaceTypeTests: XCTestCase {
         XCTAssertEqual(members[0].name, "someMethod()")
         XCTAssertEqual(members[1].name, "someExtensionMethod()")
     }
+
+    public func testToplevelSymbols() throws {
+        let source = #"""
+        public class SomeClass {
+            public func someMethod() { }
+        }
+                     
+        public infix operator ≠
+                
+        public typealias OtherClass = SomeClass
+                     
+        public func someFunction() { }
+                
+        public extension OtherClass {
+            func someExtensionMethod() { }
+        }
+        """#
+
+        let url = try temporaryFile(contents: source)
+        let sourceFile = try SourceFile(file: url, relativeTo: url.deletingLastPathComponent())
+        let module = Module(name: "Module", sourceFiles: [sourceFile])
+
+        XCTAssertEqual(module.interface.topLevelSymbols.count, 4)
+        print(module.interface.topLevelSymbols)
+
+        XCTAssertEqual(module.interface.topLevelSymbols[0].name, "SomeClass")
+        XCTAssertEqual(module.interface.topLevelSymbols[1].name, "≠")
+        XCTAssertEqual(module.interface.topLevelSymbols[2].name, "OtherClass")
+        XCTAssertEqual(module.interface.topLevelSymbols[3].name, "someFunction()")
+    }
 }

--- a/Tests/SwiftDocTests/InterfaceTypeTests.swift
+++ b/Tests/SwiftDocTests/InterfaceTypeTests.swift
@@ -382,7 +382,6 @@ final class InterfaceTypeTests: XCTestCase {
         let module = Module(name: "Module", sourceFiles: [sourceFile])
 
         XCTAssertEqual(module.interface.topLevelSymbols.count, 4)
-        print(module.interface.topLevelSymbols)
 
         XCTAssertEqual(module.interface.topLevelSymbols[0].name, "SomeClass")
         XCTAssertEqual(module.interface.topLevelSymbols[1].name, "≠")


### PR DESCRIPTION
Looks like [my assessment was wrong](https://github.com/SwiftDocOrg/swift-doc/pull/230#issuecomment-825810114) and we introduced a regression in #230. 

There's a logic error when checking which symbols are considered top-level symbols. The path of a symbol's identifier always contains the symbol's own name. Because of this, `swift-doc` version `1.0.0-beta.6` is not including all top level symbols which are not structs or classes.

This change fixes that regression and adds some tests.

I think we should add some regression tests at some point to check which symbols are included in a generated documentation.