### PR TITLE
Update Homebrew CI Workflow

### DIFF
--- a/.github/workflows/homebrew_ci.yml
+++ b/.github/workflows/homebrew_ci.yml
@@ -1,6 +1,7 @@
 name: Homebrew CI
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: 0 0 * * *
 

--- a/.github/workflows/homebrew_ci.yml
+++ b/.github/workflows/homebrew_ci.yml
@@ -1,8 +1,6 @@
 name: Homebrew CI
 
 on:
-  push:
-    branches: [master]
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
The Homebrew continuous integration workflow added in #243 currently runs on every push to `master` as well as once per day. Running on pushes to master is probably too often, and it also causes build failures when pushing new releases.

This PR replaces the push event with a manual "workflow dispatch", which adds a button on GitHub.com to test it whenever we'd like. In combination with a scheduled smoke test, I think that should strike the right balance.