### PR TITLE
Make prefix and postfix operator implementations appear in the documentation.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bug that caused prefix and postfix operators to be omitted
+  from generated documentation.
+  #262 by @Lukas-Stuehrk.
+
 ## [1.0.0-beta.6] - 2021-04-24
 
 ### Added

--- a/Sources/swift-doc/Supporting Types/Components/OperatorImplementations.swift
+++ b/Sources/swift-doc/Supporting Types/Components/OperatorImplementations.swift
@@ -53,7 +53,7 @@ struct OperatorImplementations: Component {
 
                 heading = [lhs.type, function.name, rhs.type].compactMap { $0 }.joined(separator: " ")
             case .prefix:
-                guard function.signature.input.count == 2,
+                guard function.signature.input.count == 1,
                       let operand = function.signature.input.first
                 else {
                   return nil
@@ -61,7 +61,7 @@ struct OperatorImplementations: Component {
                 heading = [function.name, operand.type].compactMap { $0 }.joined(separator: " ")
 
             case .postfix:
-                guard function.signature.input.count == 2,
+                guard function.signature.input.count == 1,
                       let operand = function.signature.input.first
                 else {
                   return nil


### PR DESCRIPTION
Both prefix and postfix operator implementations have only one argument.