### PR TITLE
Fix operator implementation visibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug that caused operator implementations to appear in the documentation
+  although they should be omitted because of their lower access level.
+  #264 by @Lukas-Stuehrk
 - Fixed bug that caused prefix and postfix operators to be omitted
   from generated documentation.
   #262 by @Lukas-Stuehrk.

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -76,7 +76,10 @@ extension SwiftDoc {
           case let `typealias` as Typealias:
             pages[route(for: `typealias`.name)] = TypealiasPage(module: module, symbol: symbol, baseURL: baseURL)
           case is Operator:
-            pages[route(for: symbol)] = OperatorPage(module: module, symbol: symbol, baseURL: baseURL, includingImplementations: symbolFilter)
+            let operatorPage = OperatorPage(module: module, symbol: symbol, baseURL: baseURL, includingImplementations: symbolFilter)
+            if !operatorPage.implementations.isEmpty {
+              pages[route(for: symbol)] = operatorPage
+            }
           case let function as Function where !function.isOperator:
             globals[function.name, default: []] += [symbol]
           case let variable as Variable:

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -76,7 +76,7 @@ extension SwiftDoc {
           case let `typealias` as Typealias:
             pages[route(for: `typealias`.name)] = TypealiasPage(module: module, symbol: symbol, baseURL: baseURL)
           case is Operator:
-            pages[route(for: symbol)] = OperatorPage(module: module, symbol: symbol, baseURL: baseURL)
+            pages[route(for: symbol)] = OperatorPage(module: module, symbol: symbol, baseURL: baseURL, includingImplementations: symbolFilter)
           case let function as Function where !function.isOperator:
             globals[function.name, default: []] += [symbol]
           case let variable as Variable:

--- a/Sources/swift-doc/Supporting Types/Pages/OperatorPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/OperatorPage.swift
@@ -9,11 +9,11 @@ struct OperatorPage: Page {
     let implementations: [Symbol]
     let baseURL: String
 
-    init(module: Module, symbol: Symbol, baseURL: String) {
+    init(module: Module, symbol: Symbol, baseURL: String, includingImplementations symbolFilter: (Symbol) -> Bool) {
         precondition(symbol.api is Operator)
         self.module = module
         self.symbol = symbol
-        self.implementations = module.interface.functionsByOperator[symbol]?.sorted() ?? []
+        self.implementations = module.interface.functionsByOperator[symbol]?.filter(symbolFilter).sorted() ?? []
         self.baseURL = baseURL
     }
 


### PR DESCRIPTION
The generated documentation could contain operator implementations which should not be included because of their access level.