### PR TITLE
swift-doc: load FoundationNetworking whenever possible

### DIFF
--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -5,7 +5,7 @@ import SwiftMarkup
 import SwiftSemantics
 import struct SwiftSemantics.Protocol
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 


### PR DESCRIPTION
Change the condition from being a platform specific check to whether the module is available.  This module is meant to be used on all non-Darwin platforms.  This repairs fetching the CSS content when using swift-doc on a Windows host.