### PR TITLE
build: bump Markup to 0.1.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/Markup.git",
         "state": {
           "branch": null,
-          "revision": "029ad8c1115ab32b7c20ab52eb092fbc030deb17",
-          "version": "0.0.4"
+          "revision": "80ddbee0048192bcbb814b016dc8ced41110d44d",
+          "version": "0.1.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.0")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
-        .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.0.3")),
+        .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.1.2")),
         .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.2.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.2")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.4.2")),


### PR DESCRIPTION
This bumps the Markup dependency to 0.1.2 to work towards adding support
for Windows.