### PR TITLE
git: ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ pnpm-lock.yaml
 
 ## Local History for Visual Studio Code
 .history/
+
+# vim swap files
+.*.sw?


### PR DESCRIPTION
For those developers who use vim, the traditional behaviour is to create
swap files next to the file itself.  These files should not be committed
to the repository, add them to the ignore list.