### PR TITLE
build: bump GraphViz dependency to 0.4.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
         "state": {
           "branch": null,
-          "revision": "e9a73a30755c3c5b26ba7c73312b1f2ccb9a1a30",
-          "version": "0.4.0"
+          "revision": "74b6cbd8c5ecea9f64d84c4e1c88d65604dd033f",
+          "version": "0.4.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.5.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.3.0")),
-        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.1")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
         .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.1.2")),
         .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.2.2")),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.5.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.3.0")),
-        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.1")),
         .package(url: "https://github.com/NSHipster/HypertextLiteral.git", .upToNextMinor(from: "0.0.2")),
         .package(url: "https://github.com/SwiftDocOrg/Markup.git", .upToNextMinor(from: "0.1.2")),
         .package(url: "https://github.com/NSHipster/SwiftSyntaxHighlighter.git", .revision("1.2.2")),


### PR DESCRIPTION
Bump the GraphViz dependency to 0.4.1 to enable support for Windows.