### PR TITLE
Expose deeplinks.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for generating documentation for
   private symbols.
-  #266 by @Lukas-Stuehrk
-  
+  #266 by @Lukas-Stuehrk.
+- Added anchor links to documentation entries for symbols.
+  #275 by @Lukas-Stuehrk.
+
 ### Fixed
 
 - Fixed bug that caused prefix and postfix operators to be omitted

--- a/Sources/swift-doc/Supporting Types/Components/Members.swift
+++ b/Sources/swift-doc/Supporting Types/Components/Members.swift
@@ -102,11 +102,12 @@ struct Members: Component {
             
                     \#(section.members.map { member -> HypertextLiteral.HTML in
                         let descriptor = String(describing: type(of: member.api)).lowercased()
+                        let id = member.id.description.lowercased().replacingOccurrences(of: " ", with: "-")
 
                         return #"""
-                        <div role="article" class="\#(descriptor)" id=\#(member.id.description.lowercased().replacingOccurrences(of: " ", with: "-"))>
+                        <div role="article" class="\#(descriptor)" id=\#(id)>
                             <h3>
-                                <code>\#(softbreak(member.name))</code>
+                                <code><a href=\#("#\(id)")>\#(softbreak(member.name))</a></code>
                             </h3>
                             \#(Documentation(for: member, in: module, baseURL: baseURL).html)
                         </div>

--- a/Sources/swift-doc/Supporting Types/Components/OperatorImplementations.swift
+++ b/Sources/swift-doc/Supporting Types/Components/OperatorImplementations.swift
@@ -69,11 +69,13 @@ struct OperatorImplementations: Component {
                 heading = [operand.type, function.name].compactMap { $0 }.joined(separator: " ")
             }
 
+            let id = implementation.id.description.lowercased().replacingOccurrences(of: " ", with: "-")
+
             return #"""
-                   <div role="article" class="function" id=\#(implementation.id.description.lowercased().replacingOccurrences(of: " ", with: "-"))>
+                   <div role="article" class="function" id=\#(id)>
                        <h3>
-                         \#(heading)
-                         \#(unsafeUnescaped: function.genericWhereClause.map({ #"<small>\#($0.escaped)</small>"# }) ?? "")
+                         <a href=\#("#\(id)")>\#(heading)
+                         \#(unsafeUnescaped: function.genericWhereClause.map({ #"<small>\#($0.escaped)</small>"# }) ?? "")</a>
                        </h3>
                        \#(Documentation(for: implementation, in: module, baseURL: baseURL).html)
                    </div>

--- a/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
@@ -70,10 +70,12 @@ struct ExternalTypePage: Page {
                     \#(section.members.map { member -> HypertextLiteral.HTML in
                     let descriptor = String(describing: type(of: member.api)).lowercased()
 
+                    let id = member.id.description.lowercased().replacingOccurrences(of: " ", with: "-")
+
                     return #"""
-                           <div role="article" class="\#(descriptor)" id=\#(member.id.description.lowercased().replacingOccurrences(of: " ", with: "-"))>
+                           <div role="article" class="\#(descriptor)" id=\#(id)>
                                <h3>
-                                   <code>\#(softbreak(member.name))</code>
+                                   <code><a href=\#("#\(id)")>\#(softbreak(member.name))</a></code>
                                </h3>
                                \#(Documentation(for: member, in: module, baseURL: baseURL).html)
                            </div>


### PR DESCRIPTION
This change adds links to the name of all members, so it's easy to copy the direct link. This implements #110.

I chose a different approach than adding a chain symbol when hovering the name. The entire name is a link. This leads to some visual changes in the generated documentation. I can change this behavior to the behavior described in the original issue if wanted.

Before the changes:
<img width="1097" alt="Screenshot 2021-05-08 at 00 12 21" src="https://user-images.githubusercontent.com/245433/117513840-de9f4d00-af92-11eb-8870-0cae58eddf69.png">

After the changes when the entire name becomes the link to the anchor:
<img width="1093" alt="Screenshot 2021-05-08 at 00 12 59" src="https://user-images.githubusercontent.com/245433/117513883-f4ad0d80-af92-11eb-98d5-3b2dd5dae338.png">
