### PR TITLE
build: bump SwiftSemantics to "main"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -74,11 +74,11 @@
         }
       },
       {
-        "package": "SwiftSyntax",
+        "package": "swift-syntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "0.50300.0",
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
+          "branch": "release/5.5",
+          "revision": "7f9f22900cda1e9eaae868012e9fcc0ecc27f1d0",
           "version": null
         }
       },
@@ -95,9 +95,9 @@
         "package": "SwiftSemantics",
         "repositoryURL": "https://github.com/SwiftDocOrg/SwiftSemantics.git",
         "state": {
-          "branch": null,
-          "revision": "2f571ccc67e0789d23f8adbccb6a18a6ff3b166c",
-          "version": "0.3.0"
+          "branch": "main",
+          "revision": "7823bf47ac183c54326df6ccf83db51eaad3c49d",
+          "version": null
         }
       },
       {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("release/5.5")),
-        .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/SwiftDocOrg/SwiftSemantics.git", .revision("main")),
         .package(url: "https://github.com/SwiftDocOrg/CommonMark.git", .upToNextMinor(from: "0.5.0")),
         .package(url: "https://github.com/SwiftDocOrg/SwiftMarkup.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .upToNextMinor(from: "0.4.1")),


### PR DESCRIPTION
This allows the package to resolve with a newer toolchain.  This is
required to get the Windows build enabled.