### PR TITLE
build: add a GHA for packaging swift-doc on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,21 @@ jobs:
   windows:
     runs-on: windows-latest
 
-    name: "Windows (Swift 5.5)"
+    name: "Windows (Swift ${{ matrix.tag }})"
+
+    strategy:
+      matrix:
+        include:
+          - tag: 5.5-DEVELOPMENT-SNAPSHOT-2021-05-09-a
+            branch: swift-5.5-branch
 
     steps:
       - uses: actions/checkout@v2
       - uses: seanmiddleditch/gha-setup-vsdevenv@master
 
-      - name: Install swift-5.5 (2021-04-19 SNAPSHOT)
+      - name: Install Swift ${{ matrix.tag }}
         run: |
-          Install-Binary -Url "https://swift.org/builds/swift-5.5-branch/windows10/swift-5.5-DEVELOPMENT-SNAPSHOT-2021-04-19-a/swift-5.5-DEVELOPMENT-SNAPSHOT-2021-04-19-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          Install-Binary -Url "https://swift.org/builds/${{ matrix.branch }}/windows10/swift-${{ matrix.tag }}/swift-${{ matrix.tag }}-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
       - name: Set Environment Variables
         run: |
           echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -126,7 +132,7 @@ jobs:
       # TODO(compnerd) figure out how to build graphviz
       - name: Fetch graphviz
         run: |
-          Invoke-WebRequest -Uri "https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC81MDQ4NS9hcnRpZmFjdE5hbWUvZ3JhcGh2aXotd2luZG93cy14NjQ1/content?format=zip" -OutFile $env:Temp\graphviz-windows-x64.zip
+          Invoke-WebRequest -Uri "https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC81MTAzNC9hcnRpZmFjdE5hbWUvZ3JhcGh2aXotd2luZG93cy14NjQ1/content?format=zip" -OutFile $env:Temp\graphviz-windows-x64.zip
           Expand-Archive -Path $env:Temp\graphviz-windows-x64.zip -Destination $env:Temp -Force
           Move-Item -Path $env:Temp\graphviz-windows-x64\Library\graphviz-development -Destination C:\Library\ -Force
       - name: Add graphviz to PATH
@@ -135,6 +141,15 @@ jobs:
       - name: Build and Test
         run: |
           swift build -v -c release -Xlinker -LC:\Library\graphviz-development\usr\lib -Xcc -DLIBXML_STATIC -Xcc -IC:\Library\libxml2-development\usr\include -Xcc -IC:\Library\libxml2-development\usr\include\libxml2 -Xlinker -LC:\Library\libxml2-development\usr\lib -Xcc -IC:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\include -Xlinker -LC:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib
+
+      - name: Package
+        run: |
+          msbuild WiX/swift-doc.wixproj -nologo -p:Configuration=Release -p:OutputPath=$PWD\.build\artifacts -p:RunWixToolsOutOfProc=true -p:GRAPHVIZ_ROOT=C:\Library\graphviz-development -p:SWIFT_DOC_BUILD=$PWD\.build\release # -p:ProductVersion=$env:GITHUB_REF.Replace('refs/tags/', '')
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: swift-doc.msi
+          path: .build\artifacts\swift-doc.msi
 
   validate-assets:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,65 @@ jobs:
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
+  windows_msi:
+    name: Build swift-doc.msi
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - tag: 5.5-DEVELOPMENT-SNAPSHOT-2021-05-09-a
+            branch: swift-5.5-branch
+    steps:
+      - uses: actions/checkout@v2
+      - uses: seanmiddleditch/gha-setup-vsdevenv@master
+
+      - name: Install Swift ${{ matrix.tag }}
+        run: |
+          Install-Binary -Url "https://swift.org/builds/${{ matrix.branch }}/windows10/swift-${{ matrix.tag }}/swift-${{ matrix.tag }}-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+      - name: Set Environment Variables
+        run: |
+          echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Adjust Paths
+        run: |
+          echo "C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install Supporting Files
+        run: |
+          Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+          Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+          Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+          Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+      - name: Fetch libxml2
+        run: |
+          Invoke-WebRequest -Uri "https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC8zNTI5NS9hcnRpZmFjdE5hbWUveG1sMi13aW5kb3dzLXg2NA2/content?format=zip" -OutFile $env:Temp\xml-windows-x64.zip
+          Expand-Archive -Path $env:Temp\xml-windows-x64.zip -DestinationPath $env:Temp -Force
+          Move-Item -Path $env:Temp\xml2-windows-x64\Library\libxml2-development -Destination C:\Library\ -Force
+      - name: Fetch graphviz
+        run: |
+          Invoke-WebRequest -Uri "https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC81MTAzNC9hcnRpZmFjdE5hbWUvZ3JhcGh2aXotd2luZG93cy14NjQ1/content?format=zip" -OutFile $env:Temp\graphviz-windows-x64.zip
+          Expand-Archive -Path $env:Temp\graphviz-windows-x64.zip -Destination $env:Temp -Force
+          Move-Item -Path $env:Temp\graphviz-windows-x64\Library\graphviz-development -Destination C:\Library\ -Force
+
+      - name: Build
+        run: |
+          swift build -c release -Xlinker -LC:\Library\graphviz-development\usr\lib -Xcc -DLIBXML_STATIC -Xcc -IC:\Library\libxml2-development\usr\include -Xcc -IC:\Library\libxml2-development\usr\include\libxml2 -Xlinker -LC:\Library\libxml2-development\usr\lib -Xcc -IC:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\include -Xlinker -LC:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib
+
+      - name: Package
+        run: |
+          msbuild WiX/swift-doc.wixproj -nologo -p:Configuration=Release -p:OutputPath=$PWD\.build\artifacts -p:RunWixToolsOutOfProc=true -p:GRAPHVIZ_ROOT=C:\Library\graphviz-development -p:SWIFT_DOC_BUILD=$PWD\.build\release -p:ProductVersion=$env:GITHUB_REF.Replace('refs/tags/', '')
+
+      - name: Upload the installer to the GitHub release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: .build\artifacts\swift-doc.msi
+          asset_name: swift-doc.msi
+          asset_content_type: application/octet-stream
+
   docker:
     name: Build and push Docker container
 

--- a/WiX/swift-doc.wixproj
+++ b/WiX/swift-doc.wixproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputName>swift-doc</OutputName>
+    <OutputType>Package</OutputType>
+    <ProjectGuid>d45046f0-1d8d-4521-bb45-17809bacf693</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>.build\artifacts\</OutputPath>
+    <IntermediateOutputPath>.build\obj\</IntermediateOutputPath>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <ProductVersion>$(ProductVersion)</ProductVersion>
+    <DefineConstants>ProductVersion=$(ProductVersion);SWIFT_DOC_BUILD=$(SWIFT_DOC_BUILD);GRAPHVIZ_ROOT=$(GRAPHVIZ_ROOT)</DefineConstants>
+  </PropertyGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+  <ItemGroup>
+    <Compile Include="swift-doc.wxs" />
+  </ItemGroup>
+</Project>

--- a/WiX/swift-doc.wxs
+++ b/WiX/swift-doc.wxs
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*"
+           Language="1033"
+           Manufacturer="swiftdoc.org"
+           Name="swift-doc"
+           UpgradeCode="1a733d92-1f0f-4d76-9737-72c698a207cd"
+           Version="$(var.ProductVersion)">
+    <Package Compressed="yes" InstallScope="perMachine" Manufacturer="swiftdoc.org"/>
+
+    <Media Id="1" Cabinet="swiftdoc.cab" CompressionLevel="high" EmbedCab="yes"/>
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="WINDOWSVOLUME">
+        <Directory Id="LIBRARY" Name="Library">
+          <Directory Id="DEVELOPER" Name="Developer">
+            <Directory Id="SWIFT_DOC" Name="SwiftDoc">
+              <Directory Id="USR" Name="usr">
+                <Directory Id="USR_BIN" Name="bin">
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
+
+    <DirectoryRef Id="USR_BIN">
+      <Component Id="SwiftDoc_BINS" Guid="6ae448ac-e535-4dd6-984a-b32ce99bcd84">
+        <File Id="SWIFT_DOC_EXE" Source="$(var.SWIFT_DOC_BUILD)\swift-doc.exe" Checksum="yes"/>
+
+        <!-- GraphViz -->
+        <File Id="CGRAPH_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\cgraph.dll" Checksum="yes"/>
+        <File Id="GVC_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\gvc.dll" Checksum="yes"/>
+        <File Id="CDT_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\cdt.dll" Checksum="yes"/>
+        <File Id="PATHPLAN_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\Pathplan.dll" Checksum="yes"/>
+        <File Id="XDOT_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\xdot.dll" Checksum="yes"/>
+        <File Id="EXPAT_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\expat.dll" Checksum="yes"/>
+        <File Id="DOT_EXE" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\dot.exe" Checksum="yes"/>
+
+        <!-- Plugins -->
+        <File Id="GVPLUGIN_CORE_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\gvplugin_core.dll" Checksum="yes"/>
+        <File Id="GVPLUGIN_DOT_LAYOUT_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\gvplugin_dot_layout.dll" Checksum="yes"/>
+        <File Id="GVPLUGIN_GDIPLUS_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\gvplugin_gdiplus.dll" Checksum="yes"/>
+        <File Id="GVPLUGIN_NEATO_LAYOUT_DLL" Source="$(var.GRAPHVIZ_ROOT)\usr\bin\gvplugin_neato_layout.dll" Checksum="yes"/>
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="TARGETDIR">
+      <Component Id="ENV_VARS" Guid="e02268ca-0ea1-421e-9c19-d1ba23dcff4e">
+        <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[WindowsVolume]Library\Developer\SwiftDoc\usr\bin"/>
+      </Component>
+    </DirectoryRef>
+
+    <Feature Id="SwiftDoc" Level="1">
+      <ComponentRef Id="SwiftDoc_BINS"/>
+      <ComponentRef Id="ENV_VARS"/>
+    </Feature>
+
+    <InstallExecuteSequence>
+      <Custom Action="CreateDotConfig" After="InstallFiles">NOT REMOVE</Custom>
+      <Custom Action="CleanupDotConfig" Before="RemoveFiles">REMOVE="ALL"</Custom>
+    </InstallExecuteSequence>
+
+    <CustomAction Id="CreateDotConfig" Directory="USR_BIN" Execute="deferred" Impersonate="no" ExeCommand="cmd /c &quot;dot -c&quot;" Return="check"/>
+    <CustomAction Id="CleanupDotConfig" Directory="USR_BIN" Execute="deferred" Impersonate="no" ExeCommand="cmd /c &quot;del config6&quot;" Return="ignore"/>
+  </Product>
+</Wix>


### PR DESCRIPTION
This adds a GitHub Action to package swift-doc for Windows for easy
distribution.  It installs to
`[WindowsVolume]\Library\Developer\SwiftDoc` by default.  This is
currently not configurable, though it likely should be.  However, this
is the simplest configuration possible and co-locates the swift-doc
package with the location of the Swift toolchain on Windows.