### PR TITLE
Fix code example used in test.

### DIFF
--- a/Tests/SwiftDocTests/InterfaceTypeTests.swift
+++ b/Tests/SwiftDocTests/InterfaceTypeTests.swift
@@ -366,7 +366,7 @@ final class InterfaceTypeTests: XCTestCase {
             public func someMethod() { }
         }
                      
-        public infix operator ≠
+        infix operator ≠
                 
         public typealias OtherClass = SomeClass
                      


### PR DESCRIPTION
Operator declarations cannot have an access level.