### PR TITLE
Add new parameter for date formats, and default to en_US

### DIFF
--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -51,7 +51,7 @@ extension SwiftDoc {
     var options: Options
 
     func run() throws {
-     let datesLocale = Locale(identifier: self.options.datesLocale)
+     let datesLocale = Locale(identifier: options.datesLocale)
     
       for directory in options.inputs {
         var isDirectory: ObjCBool = false

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -132,11 +132,29 @@ extension SwiftDoc {
         } else {
           switch format {
           case .commonmark:
-            pages["Home"] = HomePage(module: module, externalTypes: Array(symbolsByExternalType.keys), baseURL: baseURL, datesLocale: datesLocale, symbolFilter: symbolFilter)
-            pages["_Sidebar"] = SidebarPage(module: module, externalTypes: Set(symbolsByExternalType.keys), baseURL: baseURL, datesLocale: datesLocale, symbolFilter: symbolFilter)
+            pages["Home"] = HomePage(
+                module: module,
+                externalTypes: Array(symbolsByExternalType.keys),
+                baseURL: baseURL,
+                datesLocale: datesLocale,
+                symbolFilter: symbolFilter
+            )
+            pages["_Sidebar"] = SidebarPage(
+                module: module,
+                externalTypes: Set(symbolsByExternalType.keys),
+                baseURL: baseURL,
+                datesLocale: datesLocale,
+                symbolFilter: symbolFilter
+            )
             pages["_Footer"] = FooterPage(baseURL: baseURL, datesLocale: datesLocale)
           case .html:
-            pages["Home"] = HomePage(module: module, externalTypes: Array(symbolsByExternalType.keys), baseURL: baseURL, datesLocale: datesLocale, symbolFilter: symbolFilter)
+            pages["Home"] = HomePage(
+                module: module,
+                externalTypes: Array(symbolsByExternalType.keys),
+                baseURL: baseURL,
+                datesLocale: datesLocale,
+                symbolFilter: symbolFilter
+            )
           }
 
           try pages.map { $0 }.parallelForEach {

--- a/Sources/swift-doc/Supporting Types/Layout.swift
+++ b/Sources/swift-doc/Supporting Types/Layout.swift
@@ -45,7 +45,7 @@ func layout(_ page: Page) -> HTML {
         </main>
 
         <footer>
-            \#(FooterPage(baseURL: page.baseURL).html)
+            \#(FooterPage(baseURL: page.baseURL, datesLocale: page.datesLocale).html)
         </footer>
     </body>
     </html>

--- a/Sources/swift-doc/Supporting Types/Page.swift
+++ b/Sources/swift-doc/Supporting Types/Page.swift
@@ -12,6 +12,7 @@ protocol Page: HypertextLiteralConvertible {
     var title: String { get }
     var document: CommonMark.Document { get }
     var html: HypertextLiteral.HTML { get }
+    var datesLocale: Locale { get }
 }
 
 extension Page {

--- a/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/ExternalTypePage.swift
@@ -3,9 +3,9 @@ import SwiftDoc
 import HypertextLiteral
 import SwiftMarkup
 import SwiftSemantics
+import Foundation
 
 struct ExternalTypePage: Page {
-
     let module: Module
     let externalType: String
     let baseURL: String
@@ -14,11 +14,13 @@ struct ExternalTypePage: Page {
     let initializers: [Symbol]
     let properties: [Symbol]
     let methods: [Symbol]
+    let datesLocale: Locale
 
-    init(module: Module, externalType: String, symbols: [Symbol], baseURL: String) {
+    init(module: Module, externalType: String, symbols: [Symbol], baseURL: String, datesLocale: Locale) {
         self.module = module
         self.externalType = externalType
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
 
         self.typealiases = symbols.filter { $0.api is Typealias }
         self.initializers = symbols.filter { $0.api is Initializer }

--- a/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
@@ -6,6 +6,7 @@ fileprivate let dateFormatter: DateFormatter = {
     var dateFormatter = DateFormatter()
     dateFormatter.dateStyle = .long
     dateFormatter.timeStyle = .none
+    
     return dateFormatter
 }()
 
@@ -19,9 +20,11 @@ fileprivate let href = "https://github.com/SwiftDocOrg/swift-doc"
 
 struct FooterPage: Page {
     let baseURL: String
+    let datesLocale: Locale
 
-    init(baseURL: String) {
+    init(baseURL: String, datesLocale: Locale) {
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
     }
 
     // MARK: - Page
@@ -37,6 +40,8 @@ struct FooterPage: Page {
     }
 
     var html: HypertextLiteral.HTML {
+        dateFormatter.locale = datesLocale
+        
         let timestamp = timestampDateFormatter.string(from: Date())
         let dateString = dateFormatter.string(from: Date())
 

--- a/Sources/swift-doc/Supporting Types/Pages/GlobalPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/GlobalPage.swift
@@ -2,18 +2,21 @@ import SwiftSemantics
 import SwiftDoc
 import CommonMarkBuilder
 import HypertextLiteral
+import Foundation
 
 struct GlobalPage: Page {
     let module: Module
     let name: String
     let symbols: [Symbol]
     let baseURL: String
+    let datesLocale: Locale
 
-    init(module: Module, name: String, symbols: [Symbol], baseURL: String) {
+    init(module: Module, name: String, symbols: [Symbol], baseURL: String, datesLocale: Locale) {
         self.module = module
         self.name = name
         self.symbols = symbols
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
     }
 
     // MARK: - Page

--- a/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/HomePage.swift
@@ -2,10 +2,12 @@ import CommonMarkBuilder
 import SwiftDoc
 import SwiftSemantics
 import HypertextLiteral
+import struct Foundation.Locale
 
 struct HomePage: Page {
     var module: Module
     let baseURL: String
+    let datesLocale: Locale
 
     var classes: [Symbol] = []
     var enumerations: [Symbol] = []
@@ -18,9 +20,10 @@ struct HomePage: Page {
 
     let externalTypes: [String]
 
-    init(module: Module, externalTypes: [String], baseURL: String, symbolFilter: (Symbol) -> Bool) {
+    init(module: Module, externalTypes: [String], baseURL: String, datesLocale: Locale, symbolFilter: (Symbol) -> Bool) {
         self.module = module
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
 
         self.externalTypes = externalTypes
 

--- a/Sources/swift-doc/Supporting Types/Pages/OperatorPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/OperatorPage.swift
@@ -2,19 +2,22 @@ import SwiftSemantics
 import SwiftDoc
 import CommonMarkBuilder
 import HypertextLiteral
+import Foundation
 
 struct OperatorPage: Page {
     let module: Module
     let symbol: Symbol
     let implementations: [Symbol]
     let baseURL: String
+    let datesLocale: Locale
 
-    init(module: Module, symbol: Symbol, baseURL: String, includingImplementations symbolFilter: (Symbol) -> Bool) {
+    init(module: Module, symbol: Symbol, baseURL: String, datesLocale: Locale, includingImplementations symbolFilter: (Symbol) -> Bool) {
         precondition(symbol.api is Operator)
         self.module = module
         self.symbol = symbol
         self.implementations = module.interface.functionsByOperator[symbol]?.filter(symbolFilter).sorted() ?? []
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
     }
 
     // MARK: - Page

--- a/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/SidebarPage.swift
@@ -2,6 +2,7 @@ import SwiftSemantics
 import SwiftDoc
 import CommonMarkBuilder
 import HypertextLiteral
+import struct Foundation.Locale
 
 struct SidebarPage: Page {
     var module: Module
@@ -15,10 +16,12 @@ struct SidebarPage: Page {
     var globalVariableNames: Set<String> = []
 
     let externalTypes: Set<String>
+    let datesLocale: Locale
 
-    init(module: Module, externalTypes: Set<String>, baseURL: String, symbolFilter: (Symbol) -> Bool) {
+    init(module: Module, externalTypes: Set<String>, baseURL: String, datesLocale: Locale, symbolFilter: (Symbol) -> Bool) {
         self.module = module
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
 
         self.externalTypes = externalTypes
 

--- a/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypePage.swift
@@ -2,18 +2,21 @@ import SwiftSemantics
 import SwiftDoc
 import CommonMarkBuilder
 import HypertextLiteral
+import Foundation
 
 struct TypePage: Page {
     let module: Module
     let symbol: Symbol
     let baseURL: String
+    let datesLocale: Locale
     let symbolFilter: (Symbol) -> Bool
 
-    init(module: Module, symbol: Symbol, baseURL: String, includingChildren symbolFilter: @escaping (Symbol) -> Bool) {
+    init(module: Module, symbol: Symbol, baseURL: String, datesLocale: Locale, includingChildren symbolFilter: @escaping (Symbol) -> Bool) {
         precondition(symbol.api is Type)
         self.module = module
         self.symbol = symbol
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
         self.symbolFilter = symbolFilter
     }
 

--- a/Sources/swift-doc/Supporting Types/Pages/TypealiasPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/TypealiasPage.swift
@@ -2,17 +2,20 @@ import SwiftSemantics
 import SwiftDoc
 import CommonMarkBuilder
 import HypertextLiteral
+import Foundation
 
 struct TypealiasPage: Page {
     let module: Module
     let symbol: Symbol
     let baseURL: String
-
-    init(module: Module, symbol: Symbol, baseURL: String) {
+    let datesLocale: Locale
+    
+    init(module: Module, symbol: Symbol, baseURL: String, datesLocale: Locale) {
         precondition(symbol.api is Typealias)
         self.module = module
         self.symbol = symbol
         self.baseURL = baseURL
+        self.datesLocale = datesLocale
     }
 
     // MARK: - Page


### PR DESCRIPTION
Hello everyone 👋🏻 

First of all, thank you for this great tool!

While I was generating some documentation I've noticed that it was using my locale, which makes the result odd, because uses an italian word in the middle of an english sentence.

<img width="403" alt="Schermata 2021-05-22 alle 20 58 53" src="https://user-images.githubusercontent.com/17830956/119239977-bc85fd00-bb44-11eb-96fc-4e6021d1cda8.png">

I've then added a new option (that defaults to `en_US`) to specify the locale for the dates that are printed by swift docs.
I could just hardcode `en_US` there, but I thought that making it explicit with an option and allow the user to modify it was a better choice.

<img width="626" alt="Schermata 2021-05-22 alle 21 32 42" src="https://user-images.githubusercontent.com/17830956/119240049-4209ad00-bb45-11eb-8313-ad1ca8b37a32.png">

And now is correct also with my italian locale

<img width="404" alt="Schermata 2021-05-22 alle 21 47 38" src="https://user-images.githubusercontent.com/17830956/119240423-58186d00-bb47-11eb-8116-32fe7f1d1d78.png">
