### PR TITLE
Set `en_US_POSIX` locale for date formatters 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed layout of HTML output on large displays.
   #251 by @Lukas-Stuehrk and @mattt.
 
+### Changed
+
+- Changed date formatters to use `en_US_POSIX` locale instead of current locale.
+  #289 by @mattt.
+
 ## [1.0.0-beta.6] - 2021-04-24
 
 ### Added

--- a/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
+++ b/Sources/swift-doc/Supporting Types/Pages/FooterPage.swift
@@ -4,6 +4,7 @@ import HypertextLiteral
 
 fileprivate let dateFormatter: DateFormatter = {
     var dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
     dateFormatter.dateStyle = .long
     dateFormatter.timeStyle = .none
     return dateFormatter
@@ -11,6 +12,7 @@ fileprivate let dateFormatter: DateFormatter = {
 
 fileprivate let timestampDateFormatter: DateFormatter = {
     var dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
     dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
     return dateFormatter
 }()


### PR DESCRIPTION
Related to #287

The issue described in the linked PR is that, when running `swift-doc` from a non-English locale, there's a mismatch in the English text in the footer and the formatted date string. Rather than making this configurable, this PR explicitly sets the locale for date formatter instances to `en_US_POSIX`.

We can explore a complete localization strategy in a separate issue.